### PR TITLE
Remove reference to examples in Prototype Kit

### DIFF
--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -29,12 +29,6 @@
         <a href="/docs/examples/pass-data/vehicle-registration">An example of what passing data looks like in a prototype.</a>
       </p>
 
-      <p>
-        The code for the example is in this folder in the Prototype Kit:
-      </p>
-
-      <pre class="app-code" tabindex="0"><code>/docs/views/examples/pass-data</code></pre>
-
       <h2 class="govuk-heading-m">How to use</h2>
 
       <p>The kit stores data from inputs using the name attribute of the input.</p>


### PR DESCRIPTION
PR https://github.com/alphagov/govuk-prototype-kit/pull/1417 removes example files from the prototype kit, we need to update the docs to match.