### PR TITLE
Release 12.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit-docs",
-  "version": "12.1.1",
+  "version": "12.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit-docs",
-      "version": "12.1.1",
+      "version": "12.2.0",
       "dependencies": {
         "@govuk-prototype-kit/step-by-step": "^2.0.0",
         "acorn": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit-docs",
   "description": "Site for the GOV.UK Prototype Kit",
-  "version": "12.1.1",
+  "version": "12.2.0",
   "private": true,
   "engines": {
     "node": ">=12.0.0 <17.0.0"


### PR DESCRIPTION
We've released v12.2.0 of the kit (see https://github.com/alphagov/govuk-prototype-kit/issues/1508), we currently need to update package.json for the site so that users can download the latest version of the kit.