### PR TITLE
Fix redirect to update script

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -61,7 +61,7 @@ describe('The Prototype Kit', () => {
     it('should redirect to GitHub', async () => {
       const response = await request(app).get('/docs/update.sh')
       expect(response.statusCode).toBe(302)
-      expect(response.get('location')).toBe('https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/main/update.sh')
+      expect(response.get('location')).toMatch(new RegExp('https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/v[0-9]+.[0-9]+.[0-9]+/update.sh'))
     })
 
     it('should send a well formed response', async () => {

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -57,18 +57,9 @@ router.get('/update.sh', function (req, res) {
   if (req.app.locals.promoMode === 'true') {
     const version = require('../package.json').version
 
-    if (version <= 'v12.1.1') {
-      // We only started pinning the version of the kit to upgrade to after we
-      // released the current version, so we have to have this workaround until
-      // we release the next version.
-      res.redirect(
-        'https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/49fb439e56c5c7200530715176677b5e02a1ead9/update.sh'
-      )
-    } else {
-      res.redirect(
-        `https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/${version}/update.sh`
-      )
-    }
+    res.redirect(
+      `https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/${version}/update.sh`
+    )
   } else {
     res.redirect(
       'https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/main/update.sh'

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -40,31 +40,19 @@ router.get('/install/:page', function (req, res) {
 // linking to the same version being run by someone referring to the copy of the
 // docs running in their kit
 router.get('/download', function (req, res) {
-  if (req.app.locals.promoMode === 'true') {
-    const version = require('../package.json').version
+  const version = require('../package.json').version
 
-    res.redirect(
-      `https://github.com/alphagov/govuk-prototype-kit/releases/download/v${version}/govuk-prototype-kit-${version}.zip`
-    )
-  } else {
-    res.redirect(
-      'https://github.com/alphagov/govuk-prototype-kit/releases/latest'
-    )
-  }
+  res.redirect(
+    `https://github.com/alphagov/govuk-prototype-kit/releases/download/v${version}/govuk-prototype-kit-${version}.zip`
+  )
 })
 
 router.get('/update.sh', function (req, res) {
-  if (req.app.locals.promoMode === 'true') {
-    const version = require('../package.json').version
+  const version = require('../package.json').version
 
-    res.redirect(
-      `https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/${version}/update.sh`
-    )
-  } else {
-    res.redirect(
-      'https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/main/update.sh'
-    )
-  }
+  res.redirect(
+    `https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/${version}/update.sh`
+  )
 })
 
 // Examples - examples post here

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -51,7 +51,7 @@ router.get('/update.sh', function (req, res) {
   const version = require('../package.json').version
 
   res.redirect(
-    `https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/${version}/update.sh`
+    `https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/v${version}/update.sh`
   )
 })
 


### PR DESCRIPTION
We're currently pointing users to v12.1.1 of the update script because of a bug in the redirect at `/docs/update.sh` :(

We previously pointed users to the version of the kit/update script from the kit main branch if we were running the site locally. This was a holdover from when the site was also the kit however, and serves no purpose now, plus it breaks our tests to boot as there is no longer an update script in the main branch. This PR removes the offending logic, and also removes an old (no longer needed) workaround. While doing this it revealed that for the update script we had forgotten to add the `v` before the version number from the package manifest, so the comparison `version >= 'v12.1.1'` is always true and we always direct users to the workaround version :(