### PR TITLE
Lock docs to 0.0.1-alpha.3

### DIFF
--- a/cypress/scripts/run-starter-prototype.js
+++ b/cypress/scripts/run-starter-prototype.js
@@ -10,7 +10,7 @@ const defaultKitPath = path.join(os.tmpdir(), 'cypress/temp/test-project')
 
 const testDir = path.resolve(process.env.KIT_TEST_DIR || defaultKitPath)
 
-const kitModule = 'github:alphagov/govuk-prototype-kit#v13'
+const kitModule = 'govuk-prototype-kit@0.0.1-alpha.3'
 
 const npmInstall = (module) => execPromise(`cd ${testDir} && npm install ${module}`, { inherit: true })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "cypress": "^10.6.0",
         "eslint-plugin-cypress": "^2.12.1",
         "glob": "^7.1.4",
-        "govuk-prototype-kit": "alphagov/govuk-prototype-kit#v13",
+        "govuk-prototype-kit": "^0.0.1-alpha.3",
         "jest": "^28.1.1",
         "standard": "^14.3.3",
         "start-server-and-test": "^1.14.0",
@@ -5888,8 +5888,9 @@
       }
     },
     "node_modules/govuk-prototype-kit": {
-      "version": "12.1.1",
-      "resolved": "git+ssh://git@github.com/alphagov/govuk-prototype-kit.git#071cff38113340fb4787dae437fe2642e2ec921a",
+      "version": "0.0.1-alpha.3",
+      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-0.0.1-alpha.3.tgz",
+      "integrity": "sha512-tN5gYQXPwik/BN8dnQ71lfuAy5SjbBpK4reDC6uSgDlDtzyIhjVtcKYi3XUdfSZjJ+wORihldXnHvN2429JEZw==",
       "dev": true,
       "dependencies": {
         "@govuk-prototype-kit/step-by-step": "^2.0.0",
@@ -5922,10 +5923,10 @@
         "uuid": "^8.3.2"
       },
       "bin": {
-        "govuk-prototype-kit": "scripts/cli"
+        "govuk-prototype-kit": "bin/cli"
       },
       "engines": {
-        "node": ">=12.0.0 <17.0.0"
+        "node": ">=12.0.0 <19.0.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -16797,9 +16798,10 @@
       "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A=="
     },
     "govuk-prototype-kit": {
-      "version": "git+ssh://git@github.com/alphagov/govuk-prototype-kit.git#071cff38113340fb4787dae437fe2642e2ec921a",
+      "version": "0.0.1-alpha.3",
+      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-0.0.1-alpha.3.tgz",
+      "integrity": "sha512-tN5gYQXPwik/BN8dnQ71lfuAy5SjbBpK4reDC6uSgDlDtzyIhjVtcKYi3XUdfSZjJ+wORihldXnHvN2429JEZw==",
       "dev": true,
-      "from": "govuk-prototype-kit@alphagov/govuk-prototype-kit#v13",
       "requires": {
         "@govuk-prototype-kit/step-by-step": "^2.0.0",
         "acorn": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cypress": "^10.6.0",
     "eslint-plugin-cypress": "^2.12.1",
     "glob": "^7.1.4",
-    "govuk-prototype-kit": "alphagov/govuk-prototype-kit#v13",
+    "govuk-prototype-kit": "^0.0.1-alpha.3",
     "jest": "^28.1.1",
     "standard": "^14.3.3",
     "start-server-and-test": "^1.14.0",


### PR DESCRIPTION
Fix tests by locking to published govuk-prototype-kit@0.0.1-alpha.3