### PR TITLE
Ensure tests install v13 alpha 3 in test prototype

### DIFF
--- a/cypress/scripts/run-starter-prototype.js
+++ b/cypress/scripts/run-starter-prototype.js
@@ -7,7 +7,8 @@ const defaultKitPath = path.join(os.tmpdir(), 'cypress/temp/test-project')
 
 const testDir = path.resolve(process.env.KIT_TEST_DIR || defaultKitPath)
 
-const kitModule = 'govuk-prototype-kit@0.0.1-alpha.3'
+const kitVersion = '0.0.1-alpha.3'
+const kitModule = `govuk-prototype-kit@${kitVersion}`
 
 const npmInstall = (module) => child_process.execSync(`cd ${testDir} && npm install ${module}`, { inherit: true })
 
@@ -16,6 +17,6 @@ const npx = (command) => child_process.execSync(`npx ${kitModule} ${command}`, {
 fs.removeSync(testDir)
 fs.ensureDirSync(testDir)
 fs.writeJsonSync(path.join(testDir, 'usage-data-config.json'), { collectUsageData: false })
-npx('install')
+npx(`install ${kitVersion}`)
 npmInstall('@govuk-prototype-kit/step-by-step@2')
 npx('start')

--- a/cypress/scripts/run-starter-prototype.js
+++ b/cypress/scripts/run-starter-prototype.js
@@ -1,10 +1,7 @@
 const os = require('os')
 const path = require('path')
 const fs = require('fs-extra')
-const { promisify } = require('util')
 const child_process = require('child_process') // eslint-disable-line camelcase
-
-const execPromise = promisify(child_process.exec)
 
 const defaultKitPath = path.join(os.tmpdir(), 'cypress/temp/test-project')
 
@@ -12,14 +9,12 @@ const testDir = path.resolve(process.env.KIT_TEST_DIR || defaultKitPath)
 
 const kitModule = 'govuk-prototype-kit@0.0.1-alpha.3'
 
-const npmInstall = (module) => execPromise(`cd ${testDir} && npm install ${module}`, { inherit: true })
+const npmInstall = (module) => child_process.execSync(`cd ${testDir} && npm install ${module}`, { inherit: true })
 
-const npx = (command) => execPromise(`npx ${kitModule} ${command}`, { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' })
+const npx = (command) => child_process.execSync(`npx ${kitModule} ${command}`, { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' })
 
-;(async () => {
-  await fs.remove(testDir)
-  await fs.ensureDir(testDir)
-  await npx('install')
-  await npmInstall('@govuk-prototype-kit/step-by-step@2')
-  return npx('start')
-})()
+fs.removeSync(testDir)
+fs.ensureDirSync(testDir)
+npx('install')
+npmInstall('@govuk-prototype-kit/step-by-step@2')
+npx('start')

--- a/cypress/scripts/run-starter-prototype.js
+++ b/cypress/scripts/run-starter-prototype.js
@@ -15,6 +15,7 @@ const npx = (command) => child_process.execSync(`npx ${kitModule} ${command}`, {
 
 fs.removeSync(testDir)
 fs.ensureDirSync(testDir)
+fs.writeJsonSync(path.join(testDir, 'usage-data-config.json'), { collectUsageData: false })
 npx('install')
 npmInstall('@govuk-prototype-kit/step-by-step@2')
 npx('start')


### PR DESCRIPTION
In PR #42 we tried to make sure that the tests for this repo would use the use a specific version of the kit, so that the docs tests are predictable.

This PR adds the desired version to the command line for the kit install script, because otherwise it will default to the latest published version.

This should mean the PR checks for this repo start passing again, as the tests were written for that version of the kit.

Fixes #47.