### PR TITLE
Add npm script dev to make running site locally easier

### DIFF
--- a/lib/build/build-watch-and-serve
+++ b/lib/build/build-watch-and-serve
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const { buildWatchAndServe } = require('./tasks')
+
+buildWatchAndServe()

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "node lib/build/generate-assets",
+    "dev": "node lib/build/build-watch-and-serve",
     "serve": "node listen-on-port",
     "lint": "standard",
     "rapidtest": "jest --bail",

--- a/server.js
+++ b/server.js
@@ -266,7 +266,6 @@ app.use(function (err, req, res, next) {
   res.send(err.message)
 })
 
-console.log('\nGOV.UK Prototype Kit v' + releaseVersion)
-console.log('\nNOTICE: the kit is for building prototypes, do not use it for production services.')
+console.log('\nGOV.UK Prototype Kit v' + releaseVersion + ' -- website')
 
 module.exports = app


### PR DESCRIPTION
You can now run `npm run dev` on your machine to get a development server.