### PR TITLE
Update Node.js LTS version number

### DIFF
--- a/docs/documentation/install/developer-install-instructions.md
+++ b/docs/documentation/install/developer-install-instructions.md
@@ -11,7 +11,7 @@ If you already installed a previous version of the Prototype Kit, you can [updat
 
 ## Requirements
 
-node.js - version 16.x.x
+node.js - version 18.x.x
 
 ## Install dependencies
 

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -17,7 +17,7 @@ GDS staff can install the software themselves with the Self Service app.
 
 You'll need:
 
-* Node.js 16.x.x
+* Node.js 18.x.x
 * Git Bash (if you're using Windows, see below)
 
 ## Terminal
@@ -43,9 +43,9 @@ Download [Git Bash (direct download)](https://git-scm.com/download/win).
 
 Install with all the default options.
 
-## Node.js version 16 LTS
+## Node.js version 18 LTS
 
-The kit is designed to work with Node.js version 16 LTS. The kit works with any 16.x.x version.
+The kit is designed to work with Node.js version 18 LTS. The kit works with any 18.x.x version.
 
 ### Check if you have Node.js
 
@@ -55,21 +55,21 @@ node --version
 ```
 If it says `command not found` or `Error 0x2 starting node.exe --version` you don’t have Node and will need to download and install it.
 
-If the version number starts with 16 you have the correct version installed.
+If the version number starts with 18 you have the correct version installed.
 
-If it says another number such as `0.12` or `5.x.x`, you need to download and install version 16.
+If it says another number such as `0.12` or `5.x.x`, you need to download and install version 18.
 
 ### Download and install Node.js
 
 #### Mac / Windows users
 
-[Download version 16 from the Node.js website.](https://nodejs.org/en/)
+[Download version 18 from the Node.js website.](https://nodejs.org/en/)
 
 Run the installer with all default options.
 
 #### Linux users
 
-[Follow the Linux instructions on the Node.js. website.](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) Make sure you get version 16.
+[Follow the Linux instructions on the Node.js. website.](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) Make sure you get version 18.
 
 ### Once Node is installed
 
@@ -80,6 +80,6 @@ To check it is installed correctly you can again run:
 node --version
 ```
 
-If it’s installed correctly it should show a number starting with 16.
+If it’s installed correctly it should show a number starting with 18.
 
 <a href="install-the-kit.md" class="button">Next (How to install the kit)</a>


### PR DESCRIPTION
Node have updated the current long term support (LTS) version to 18.12.0, we should update our docs to reflect this.