### PR TITLE
Use latest version of Node.js 16

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-16.15.0
+lts/gallium

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <17.0.0"
+    "node": "16.x"
   },
   "scripts": {
     "build": "node lib/build/generate-assets",


### PR DESCRIPTION
Make sure devs and Heroku are using the latest version of Node.js 16, with all security fixes.