### PR TITLE
Use relative links for Markdown pages in v12 docs

### DIFF
--- a/docs/v12/documentation/accessibility.md
+++ b/docs/v12/documentation/accessibility.md
@@ -47,11 +47,11 @@ The test was carried out by the GOV.UK Prototype Kit team.
 
 The GOV.UK Prototype Kit team tested a sample of pages to cover the different content types in the Prototype Kit website. They were:
 
-- [the homepage](/docs)
-- [the tutorials and templates page](/docs/tutorials-and-examples)
-- [the tutorial pages](/docs/make-first-prototype/start)
-- [the guide pages](/docs/publishing-on-heroku)
-- [the example pages](/docs/examples/pass-data)
+- [the homepage](./)
+- [the tutorials and templates page](./tutorials-and-examples)
+- [the tutorial pages](./make-first-prototype/start)
+- [the guide pages](./publishing-on-heroku)
+- [the example pages](./examples/pass-data)
 
 ### How the GOV.UK Prototype Kit team makes this website accessible
 

--- a/docs/v12/documentation/backwards-compatibility.md
+++ b/docs/v12/documentation/backwards-compatibility.md
@@ -28,7 +28,7 @@ In Atom, press **cmd shift F**. It looks like this:
 
 ![Screenshot of section of the Atom user interface with: a text field that contains '/public/'; a button labelled 'find all'; a text field containing '/public/v6'; and a button labelled 'replace all'.](/public/docs/v12/images/docs/backwards-compatibility-atom.png)
 
-1. [Download the latest Prototype Kit](/docs/download) and unzip it.
+1. [Download the latest Prototype Kit](./download) and unzip it.
 
 1. Copy everything from the new Prototype Kit folder into your prototype folder.
 

--- a/docs/v12/documentation/install/developer-install-instructions.md
+++ b/docs/v12/documentation/install/developer-install-instructions.md
@@ -5,9 +5,9 @@ caption: Install the Prototype Kit
 
 The Prototype Kit is built on the [Express framework](http://expressjs.com/), and uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend).
 
-If you already installed a previous version of the Prototype Kit, you can [update the kit](/docs/updating-the-kit) instead.
+If you already installed a previous version of the Prototype Kit, you can [update the kit](../updating-the-kit) instead.
 
-[Download the Prototype Kit (zip file)](https://govuk-prototype-kit.herokuapp.com/docs/download) if you have not already.
+[Download the Prototype Kit (zip file)](../download) if you have not already.
 
 ## Requirements
 

--- a/docs/v12/documentation/install/install-the-kit.md
+++ b/docs/v12/documentation/install/install-the-kit.md
@@ -74,4 +74,4 @@ npm install
 The install may take about a minute. Whilst installing, it may `WARN` about some items - this is ok. As long as there are no `ERROR`s, you can continue.
 
 
-<a href="run-the-kit.md" class="button">Next (How to run the kit)</a>
+<a href="run-the-kit" class="button">Next (How to run the kit)</a>

--- a/docs/v12/documentation/install/introduction.md
+++ b/docs/v12/documentation/install/introduction.md
@@ -7,7 +7,7 @@ This guide will walk you through installing and getting started with the kit. Yo
 
 Installation takes up to 30 minutes depending on how much you need to install.
 
-If you already installed a previous version of the Prototype Kit, you can [update your Prototype Kit](/docs/updating-the-kit) instead.
+If you already installed a previous version of the Prototype Kit, you can [update your Prototype Kit](../updating-the-kit) instead.
 
 If you’re comfortable using git and the terminal, you may prefer the [guide for advanced users](developer-install-instructions).
 

--- a/docs/v12/documentation/install/introduction.md
+++ b/docs/v12/documentation/install/introduction.md
@@ -21,4 +21,4 @@ The GOV.UK Prototype Kit provides a simple way to make interactive prototypes th
 
 You’ll use a copy of the kit for each different prototype you want to make - they’re self contained. Once installed, the kit uses about 100mb.
 
-<a href="requirements.md" class="button">Next (Prototype Kit requirements)</a>
+<a href="requirements" class="button">Next (Prototype Kit requirements)</a>

--- a/docs/v12/documentation/install/requirements.md
+++ b/docs/v12/documentation/install/requirements.md
@@ -5,7 +5,7 @@ caption: Installation guide for new users
 
 The GOV.UK Prototype Kit runs on Mac, Windows and Linux. At a minimum you’ll need Node.js (install instructions below) and a web browser.
 
-[If you're using an M1 Mac issued in 2020 or later](https://en.wikipedia.org/wiki/Apple_M1#Products_that_include_the_Apple_M1), you might experience issues when you run the Prototype Kit. To get support, [contact the Prototype team](/docs/about).
+[If you're using an M1 Mac issued in 2020 or later](https://en.wikipedia.org/wiki/Apple_M1#Products_that_include_the_Apple_M1), you might experience issues when you run the Prototype Kit. To get support, [contact the Prototype team](../about).
 
 ## Software you need
 

--- a/docs/v12/documentation/install/requirements.md
+++ b/docs/v12/documentation/install/requirements.md
@@ -82,4 +82,4 @@ node --version
 
 If it’s installed correctly it should show a number starting with 18.
 
-<a href="install-the-kit.md" class="button">Next (How to install the kit)</a>
+<a href="install-the-kit" class="button">Next (How to install the kit)</a>

--- a/docs/v12/documentation/install/run-the-kit.md
+++ b/docs/v12/documentation/install/run-the-kit.md
@@ -52,8 +52,8 @@ To quit the kit, in the terminal press the `ctrl` and `c` keys together.
 
 The kit is now installed. Congratulations!
 
-The Prototype Kit is updated regularly. We announce new versions of the Prototype Kit in the [#prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit/). You should [update to the latest version of the kit](/docs/updating-the-kit) to get the latest components, new features and fixes.
+The Prototype Kit is updated regularly. We announce new versions of the Prototype Kit in the [#prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit/). You should [update to the latest version of the kit](../updating-the-kit) to get the latest components, new features and fixes.
 
 ## Make your first prototype
 
-You can now start the tutorial to [make your first prototype](/docs/make-first-prototype/start).
+You can now start the tutorial to [make your first prototype](../make-first-prototype/start).

--- a/docs/v12/documentation/make-first-prototype/link-index-page-start-page.md
+++ b/docs/v12/documentation/make-first-prototype/link-index-page-start-page.md
@@ -8,4 +8,4 @@ You can route users from your service's index page to your start page. The index
 1. Open the `index.html` file in your `app/views` folder.
 2. Add an `<a>` tag that links to `/start`.
 
-You can now find out [how to publish your prototype online](/docs/publishing), so you can share it with your team or do user research.
+You can now find out [how to publish your prototype online](../publishing), so you can share it with your team or do user research.

--- a/docs/v12/documentation/updating-the-kit.md
+++ b/docs/v12/documentation/updating-the-kit.md
@@ -29,7 +29,7 @@ In Finder on Mac or Windows Explorer, go to your prototype folder and open the f
 
 1. Make a backup of your prototype folder. You can do this in Finder or Windows Explorer. This may take a few minutes.
 
-2. In the [terminal](https://govuk-prototype-kit.herokuapp.com/docs/install/requirements.md#terminal), `cd` to your prototype folder.
+2. In the [terminal](./install/requirements#terminal), `cd` to your prototype folder.
 
 3. Run this command:
 
@@ -80,5 +80,5 @@ To fix this:
 
 If you need to restart the Prototype Kit after the fix:
 
-1. in your [terminal](https://govuk-prototype-kit.herokuapp.com/docs/install/requirements.md#terminal), `cd` to your prototype folder
+1. in your [terminal](./install/requirements#terminal), `cd` to your prototype folder
 2. run `npm start`


### PR DESCRIPTION
These were missed in commit 0ea1609911.