### PR TITLE
Use baseUrl for GOV.UK and Prototype Kit links in header for documentation

### DIFF
--- a/docs/v12/views/layout.html
+++ b/docs/v12/views/layout.html
@@ -31,10 +31,10 @@
 {% endblock %}
 
 {% block header %}
-  {# Set serviceName in config.js. #}
   {{ govukHeader({
+    homepageUrl: baseUrl,
     serviceName: serviceName,
-    serviceUrl: "/",
+    serviceUrl: baseUrl,
     navigation: [
       {
         href: baseUrl + "/install",


### PR DESCRIPTION
Make sure the links in the header will take the user to the homepage for the version of the docs they are reading.