### PR TITLE
Add inset text pointing users to v12 docs

### DIFF
--- a/docs/v13/documentation/create-pages-from-templates.md
+++ b/docs/v13/documentation/create-pages-from-templates.md
@@ -37,3 +37,11 @@ Read the [Start using a service guidance](https://design-system.service.gov.uk/p
 ## Using step by step navigation
 
 Step by step navigation is for a page outside your transactional service. It’s in the Prototype Kit so you can prototype your journeys for testing. Step by step is available as a plugin.
+
+<!-- TODO: replace with Nunjucks partial _new-version-inset-text -->
+<div class="govuk-inset-text">
+  <strong class="govuk-body govuk-!-font-weight-bold">
+    This has changed in version 13, if you are using a previous version, see the
+    <a class="govuk-link" href="/v12/docs">old documentation</a>
+  </strong>
+</div>

--- a/docs/v13/documentation/install/getting-started.md
+++ b/docs/v13/documentation/install/getting-started.md
@@ -12,3 +12,11 @@ It takes up to 30 minutes depending on how much you need to set up.
 There is an [getting started advanced guide](./getting-started-advanced) if you’re comfortable using Git and the terminal.
 
 [How to run the kit](./how-to-run-the-kit)
+
+<!-- TODO: replace with Nunjucks partial _new-version-inset-text -->
+<div class="govuk-inset-text">
+  <strong class="govuk-body govuk-!-font-weight-bold">
+    This has changed in version 13, if you are using a previous version, see the
+    <a class="govuk-link" href="/v12/docs">old documentation</a>
+  </strong>
+</div>

--- a/docs/v13/documentation/make-first-prototype/open-prototype-in-editor.md
+++ b/docs/v13/documentation/make-first-prototype/open-prototype-in-editor.md
@@ -19,3 +19,11 @@ In your text editor open your prototype folder. You will see the files and folde
   - `routes.js` is for advanced logic - for example, if a user should go to one page or another based on their answer
 
 [Next (create pages)](create-pages)
+
+<!-- TODO: replace with Nunjucks partial _new-version-inset-text -->
+<div class="govuk-inset-text">
+  <strong class="govuk-body govuk-!-font-weight-bold">
+    This has changed in version 13, if you are using a previous version, see the
+    <a class="govuk-link" href="/v12/docs">old documentation</a>
+  </strong>
+</div>

--- a/docs/v13/documentation/update-to-latest-version.md
+++ b/docs/v13/documentation/update-to-latest-version.md
@@ -21,3 +21,11 @@ You will need to do this for each prototype you are working on.
 If you have a question or need help [contact the GOV.UK Prototype team](./support)
 
 Tell us as much as you can about the issue you're having and the operating system you're using.
+
+<!-- TODO: replace with Nunjucks partial _new-version-inset-text -->
+<div class="govuk-inset-text">
+  <strong class="govuk-body govuk-!-font-weight-bold">
+    This has changed in version 13, if you are using a previous version, see the
+    <a class="govuk-link" href="/v12/docs">old documentation</a>
+  </strong>
+</div>

--- a/docs/v13/views/create-new-prototype.html
+++ b/docs/v13/views/create-new-prototype.html
@@ -16,23 +16,20 @@ Create a new prototype
 {% endblock %}
 
 {% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Create a new prototype</h1>
 
-      <h1 class="govuk-heading-xl">Create a new prototype</h1>
+    <p>Choose from:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>create a prototype <a href="./install/getting-started">for new users</a></li>
+      <li>create a prototype <a href="./install/getting-started-advanced">for advanced users</a> familiar with Node.js, Git and the terminal</li>
+      <li><a href="./update-to-latest-version">update to the latest version of the Prototype Kit</a></li>
+    </ul>
 
-      <p>Choose from:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>create a prototype <a href="./install/getting-started">for new users</a></li>
-        <li>create a prototype <a href="./install/getting-started-advanced">for advanced users</a> familiar with Node.js, Git and the terminal</li>
-        <li><a href="./update-to-latest-version">update to the latest version of the Prototype Kit</a></li>
-      </ul>
+    {% include "_new-version-inset-text.njk" %}
 
   </div>
-
-
 </div>
-
-
 {% endblock %}

--- a/docs/v13/views/index.html
+++ b/docs/v13/views/index.html
@@ -49,4 +49,6 @@ GOV.UK Prototype Kit
     </div>
 
   </div>
+
+  {% include "_new-version-inset-text.njk" %}
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -191,10 +191,16 @@ app.use('/v*/docs', function (req, res, next) {
 
 // Create separate routers for each version of docs
 app.use('/v12/docs',
-  createDocumentationApp('./docs/v12', { locals: { docsVersionName: 'versions 7, 8, 9, 10, 11 and 12' } })
+  createDocumentationApp(
+    './docs/v12',
+    { locals: { docsVersionName: 'versions 7, 8, 9, 10, 11 and 12' } }
+  )
 )
 app.use(['/v13/docs', '/docs'],
-  createDocumentationApp('./docs/v13', { latest: true })
+  createDocumentationApp(
+    './docs/v13',
+    { latest: true, locals: { docsVersionName: 'version 13' } }
+  )
 )
 
 // Strip .html and .htm if provided

--- a/views/partials/_new-version-inset-text.njk
+++ b/views/partials/_new-version-inset-text.njk
@@ -1,0 +1,12 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set html %}
+  <strong class="govuk-body govuk-!-font-weight-bold">
+    This has changed in {{ docsVersionName }}, if you are using a previous version, see the
+    <a class="govuk-link" href="/v12/docs">old documentation</a>
+  </strong>
+{% endset %}
+
+{{ govukInsetText({
+  html: html
+}) }}


### PR DESCRIPTION
For certain pages, add inset text pointing them to the v12 docs, in case they are still using the old version of the kit.

Closes https://github.com/alphagov/govuk-prototype-kit-docs/issues/80.