### PR TITLE
Update docs to reflect new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # GOV.UK Prototype Kit
 
-Go to the [GOV.UK Prototype Kit site](https://govuk-prototype-kit.herokuapp.com/docs) to download the latest version and read the documentation.
+Go to the [GOV.UK Prototype Kit site](https://prototype-kit.service.gov.uk/docs/) to download the latest version and read the documentation.
 
 ## About the Prototype Kit
 
 The Prototype Kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research.
 
-Read the [project principles](https://govuk-prototype-kit.herokuapp.com/docs/principles).
+Read the [project principles](https://prototype-kit.service.gov.uk/docs/principles).
 
 ## Make sure prototypes are password-protected
 
-If you publish your prototypes online, they **must** be protected by a [username and password](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku). This is to prevent members of the public finding prototypes and thinking they are real services.
+If you publish your prototypes online, they **must** be protected by a [username and password](https://prototype-kit.service.gov.uk/docs/publishing-on-heroku). This is to prevent members of the public finding prototypes and thinking they are real services.
 
 You must protect user privacy at all times, even when using prototypes. Prototypes made with the kit look like GOV.UK, but do not have the same security provisions. Always make sure you are handling user data appropriately.
 
 ## Installation instructions
 
-- [Installation guide for new users (non technical)](https://govuk-prototype-kit.herokuapp.com/docs/install/introduction)
-- [Installation guide for developers (technical)](https://govuk-prototype-kit.herokuapp.com/docs/install/developer-install-instructions)
+- [Installation guide for new users (non technical)](https://prototype-kit.service.gov.uk/docs/install/introduction)
+- [Installation guide for developers (technical)](https://prototype-kit.service.gov.uk/docs/install/developer-install-instructions)
 
 ## Support
 

--- a/docs/v12/documentation/accessibility.md
+++ b/docs/v12/documentation/accessibility.md
@@ -8,7 +8,7 @@ This page explains how the team works to ensure the Prototype Kit website is acc
 
 ## Accessibility statement for the GOV.UK Prototype Kit website
 
-This accessibility statement applies to the GOV.UK Prototype Kit documentation website at https://govuk-prototype-kit.herokuapp.com
+This accessibility statement applies to the GOV.UK Prototype Kit documentation website at https://prototype-kit.service.gov.uk
 
 The GOV.UK Prototype team wants as many people as possible to be able to use this website. For example, that means you should be able to:
 
@@ -36,7 +36,7 @@ GDS is committed to making its websites accessible, in accordance with the Publi
 
 ### Compliance status
 
-The Prototype Kit website at [https://govuk-prototype-kit.herokuapp.com](/) is fully compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard.
+The Prototype Kit website at [https://prototype-kit.service.gov.uk](/) is fully compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard.
 
 
 ### How this website has been tested for accessibility

--- a/docs/v12/documentation/updating-the-kit.md
+++ b/docs/v12/documentation/updating-the-kit.md
@@ -34,7 +34,7 @@ In Finder on Mac or Windows Explorer, go to your prototype folder and open the f
 3. Run this command:
 
 ```
-curl -L https://govuk-prototype-kit.herokuapp.com/docs/update.sh | bash
+curl -L https://prototype-kit.service.gov.uk/docs/update.sh | bash
 ```
 
 It will download a zip file and unzip the latest version of the Prototype Kit into a new `update` folder.

--- a/docs/v12/views/privacy-notice.html
+++ b/docs/v12/views/privacy-notice.html
@@ -29,7 +29,7 @@ Privacy notice – GOV.UK Prototype Kit
    
    <h2 class="govuk-heading-l">What data we collect from you</h2>
    
-    <p>We collect certain information and data about you when you use the <a href="https://govuk-prototype-kit.herokuapp.com/docs">GOV.UK Prototype Kit</a>. </p>
+    <p>We collect certain information and data about you when you use the <a href="https://prototype-kit.service.gov.uk/docs">GOV.UK Prototype Kit</a>. </p>
     
     <p>We collect your user profile if you interact with us on collaboration tools and platforms</p>
     

--- a/internal_docs/deploys.md
+++ b/internal_docs/deploys.md
@@ -1,12 +1,17 @@
 # Deploys
 
 This repo uses [Heroku automatic deploys] to deploy the latest code in the
-`main` branch directly to https://govuk-prototype-kit.herokuapp.com/.
+`main` branch directly to https://prototype-kit.service.gov.uk.
+
+The custom domain is managed by GOV.UK, see [ticket #71] for more details. We
+redirect users from the Heroku domain to the custom domain when the
+`HEROKU_APP_NAME` and `HEROKU_CUSTOM_DOMAIN` environment variables are set,
+which we set by hand as config vars in the Heroku app dashboard.
 
 Deployments are configured manually using the dashboard for the
-[govuk-prototype-kit pipeline]. To check the configuration or any deployment
-issues, log into Heroku using the [team credentials].
+[govuk-prototype-kit-docs pipeline]. To check the configuration or any
+deployment issues, log into Heroku using the team credentials in Bitwarden.
 
 [Heroku automatic deploys]: https://devcenter.heroku.com/articles/github-integration#automatic-deploys
-[govuk-prototype-kit pipeline]: https://dashboard.heroku.com/pipelines/f0879aaf-21f5-4430-a1d5-7adc4740a066
-[team credentials]: https://github.com/alphagov/design-system-team-credentials/tree/main/heroku
+[ticket #71]: https://github.com/alphagov/govuk-prototype-kit-docs/issues/71
+[govuk-prototype-kit-docs pipeline]: https://dashboard.heroku.com/pipelines/f0879aaf-21f5-4430-a1d5-7adc4740a066

--- a/internal_docs/review-apps.md
+++ b/internal_docs/review-apps.md
@@ -9,9 +9,9 @@ not be created automatically. However, you can create a review app manually
 from the Heroku dashboard.
 
 Previews of pull requests are automatically published to a URL which has the
-prefix `govuk-prototype-kit` followed by the identifier number of the pull request.
+prefix `prototype-kit-docs` followed by the identifier number of the pull request.
 
-For example, pull request #137 would be deployed to `govuk-prototype-kit-pr-137.herokuapp.com`.
+For example, pull request #137 would be deployed to `prototype-kit-docs-pr-137.herokuapp.com`.
 
 As Heroku builds and deploys the review app, it will create a GitHub deployment
 with the @govuk-design-system-ci user. The deployment will appear both as an


### PR DESCRIPTION
We're now using the URL prototype-kit.service.gov.uk for these docs, let's update our content to reflect that.