### PR TITLE
Link to requirements page from getting started page

### DIFF
--- a/docs/v13/documentation/install/getting-started.md
+++ b/docs/v13/documentation/install/getting-started.md
@@ -11,7 +11,7 @@ It takes up to 30 minutes depending on how much you need to set up.
 
 There is an [getting started advanced guide](./getting-started-advanced) if you’re comfortable using Git and the terminal.
 
-[How to run the kit](./how-to-run-the-kit)
+[Next (Requirements)](./requirements)
 
 <!-- TODO: replace with Nunjucks partial _new-version-inset-text -->
 <div class="govuk-inset-text">


### PR DESCRIPTION
We want users to be able to follow the 'Get started' link on the homepage and be led to the command `npx govuk-prototype-kit create`. This commit makes sure that the 'new user' journey includes that command, by taking them into the 'getting started' flow that is on the tutorials and templates page. There is probably a nicer way to do this, but this is quick and easy for now.