### PR TITLE
Add redirect from /docs/install

### DIFF
--- a/server.js
+++ b/server.js
@@ -189,6 +189,11 @@ app.use('/v*/docs', function (req, res, next) {
   next()
 })
 
+// Add redirect from v12 /install to v13 /create-new-prototype
+app.get('/docs/install', (req, res) => {
+  res.redirect('/docs/create-new-prototype')
+})
+
 // Create separate routers for each version of docs
 app.use('/v12/docs',
   createDocumentationApp(


### PR DESCRIPTION
GOV.UK Design System links to /docs/install, but in the new docs that page is gone. Point users to the new page at /docs/create-a-new-prototype until we can update all uses of that old URL.