### PR TITLE
Add redirect from /docs/templates/* to /v12/docs/templates/*

### DIFF
--- a/server.js
+++ b/server.js
@@ -194,6 +194,12 @@ app.get('/docs/install', (req, res) => {
   res.redirect('/docs/create-new-prototype')
 })
 
+// Add redirect from /templates url to v12 docs for now
+// TODO: figure out what to do with templates
+app.use('/docs/templates', (req, res, next) => {
+  res.redirect('/v12/docs/templates' + req.path)
+})
+
 // Create separate routers for each version of docs
 app.use('/v12/docs',
   createDocumentationApp(


### PR DESCRIPTION
In the v13 docs, we removed the templates from the website. We did this because the plugin architecture means templates are now decoupled from the version of the kit a user has. They might have different templates, or different versions of the same template, to what we show on the website. As the kit also now has a better built-in way to preview what a page would look like once created from a template, it seemed like there was no need to have the templates viewable on the web.

However, what we didn't realise is that the GOV.UK Design System website links to the template previews on our website, as a way of sharing with their users what an example use of a component or pattern might look like (see PR alphagov/govuk-design-system#2428). I'm not in a position to figure out if this is how we want templates to be used in future, or if there is a better way of fulfilling this use-case, so for now I'm deferring the decision. The `/docs/templates/*` URLs will work as before, just pointing the user to the v12 version.

In future we might want to install the latest version of selected plugins and host those templates, or we might want to negotiate with the Design System team for them to find another way to get the examples they need.