### PR TITLE
Fix update script URL in v12 docs

### DIFF
--- a/docs/v12/documentation/updating-the-kit.md
+++ b/docs/v12/documentation/updating-the-kit.md
@@ -34,7 +34,7 @@ In Finder on Mac or Windows Explorer, go to your prototype folder and open the f
 3. Run this command:
 
 ```
-curl -L https://prototype-kit.service.gov.uk/docs/update.sh | bash
+curl -L https://prototype-kit.service.gov.uk/v12/docs/update.sh | bash
 ```
 
 It will download a zip file and unzip the latest version of the Prototype Kit into a new `update` folder.


### PR DESCRIPTION
The update script is no longer used by the latest version of the kit, update the v12 docs to include the version in the URL for the update script, so users can still follow the v12 docs to update to v12 if they need to.