### PR TITLE
Improve design of Next links

### DIFF
--- a/docs/v13/documentation/install/create-a-prototype.md
+++ b/docs/v13/documentation/install/create-a-prototype.md
@@ -48,4 +48,11 @@ Run:
 
 `npx govuk-prototype-kit create`
 
-<a href="how-to-run-the-kit" class="button">Next (How to run the kit)</a>
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="how-to-run-the-kit" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">How to run the kit</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/install/getting-started.md
+++ b/docs/v13/documentation/install/getting-started.md
@@ -11,7 +11,16 @@ It takes up to 30 minutes depending on how much you need to set up.
 
 There is an [getting started advanced guide](./getting-started-advanced) if you’re comfortable using Git and the terminal.
 
-[Next (Requirements)](./requirements)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="./requirements" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Requirements</span></a>
+  </div>
+</nav>
+
+<hr>
 
 <!-- TODO: replace with Nunjucks partial _new-version-inset-text -->
 <div class="govuk-inset-text">

--- a/docs/v13/documentation/install/requirements.md
+++ b/docs/v13/documentation/install/requirements.md
@@ -81,4 +81,11 @@ node --version
 
 If it’s installed correctly it should show a number starting with 18.
 
-<a href="create-a-prototype" class="button">Next (Create a prototype)</a>
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="create-a-prototype" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Create a prototype</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/make-first-prototype/branching.md
+++ b/docs/v13/documentation/make-first-prototype/branching.md
@@ -85,4 +85,11 @@ The first line of this sample output ends with `/app/routes.js:12`.
 
 The '12' suggests there’s probably an issue on line 12 or the line before it. In this case, the issue was a missing bracket.
 
-[Next (Link your index page to your start page)](link-index-page-start-page)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="link-index-page-start-page" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Link your index page to your start page</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/make-first-prototype/create-pages.md
+++ b/docs/v13/documentation/make-first-prototype/create-pages.md
@@ -72,4 +72,11 @@ Create a page from the **Confirmation** template.
 
 Enter the path `/confirmation`.
 
-[Next (link your pages together)](link-pages-together)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="link-pages-together" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">link your pages together</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/make-first-prototype/let-user-change-answers.md
+++ b/docs/v13/documentation/make-first-prototype/let-user-change-answers.md
@@ -64,4 +64,11 @@ Add `value: data['most-impressive-trick']` like this:
 
 [Go to http://localhost:3000/juggling-trick](http://localhost:3000/juggling-trick) and check it works by filling in an answer, continuing to the next page, going back, then refreshing your browser.
 
-[Next (Show different pages depending on user input)](branching)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="branching" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Show different pages depending on user input</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/make-first-prototype/link-pages-together.md
+++ b/docs/v13/documentation/make-first-prototype/link-pages-together.md
@@ -38,4 +38,11 @@ This time it's a real HTML button, not a link. Buttons submit form data - the UR
 
 The 'Check answers' page template links to the ‘Confirmation’ page by default. So you do not need to change the ‘Check answers’ page.
 
-[Next (use components from the Design System)](use-components)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="use-components" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Use components from the Design System</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/make-first-prototype/open-prototype-in-editor.md
+++ b/docs/v13/documentation/make-first-prototype/open-prototype-in-editor.md
@@ -18,7 +18,16 @@ In your text editor open your prototype folder. You will see the files and folde
   - `assets` is for CSS, JavaScript, images and downloadable files
   - `routes.js` is for advanced logic - for example, if a user should go to one page or another based on their answer
 
-[Next (create pages)](create-pages)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="create-pages" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Create pages</span></a>
+  </div>
+</nav>
+
+<hr>
 
 <!-- TODO: replace with Nunjucks partial _new-version-inset-text -->
 <div class="govuk-inset-text">

--- a/docs/v13/documentation/make-first-prototype/show-users-answers.md
+++ b/docs/v13/documentation/make-first-prototype/show-users-answers.md
@@ -112,4 +112,11 @@ Your code should now look like this:
 </div>
 ```
 
-[Next (Let the user change their answers)](let-user-change-answers)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="let-user-change-answers" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Let the user change their answers</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/make-first-prototype/start.md
+++ b/docs/v13/documentation/make-first-prototype/start.md
@@ -29,7 +29,14 @@ You'll also need a code editor. These two are popular, well established and fair
  - [VS Code](https://code.visualstudio.com)
  - [Notepad++](https://notepad-plus-plus.org) (Windows only)
 
-[Next (open your prototype in your editor)](open-prototype-in-editor)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="open-prototype-in-editor" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Open your prototype in your editor</span></a>
+  </div>
+</nav>
 
 <hr>
 

--- a/docs/v13/documentation/make-first-prototype/use-components-2.md
+++ b/docs/v13/documentation/make-first-prototype/use-components-2.md
@@ -38,4 +38,11 @@ Your page should now look like this:
 <figcaption class="govuk-body">Screenshot of how your prototype should look.</figcaption>
 </figure>
 
-[Next (Show the user’s answers on your ‘Check answers’ page)](show-users-answers)
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="show-users-answers" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Show the user’s answers on the ‘Check answers’ page</span></a>
+  </div>
+</nav>

--- a/docs/v13/documentation/make-first-prototype/use-components.md
+++ b/docs/v13/documentation/make-first-prototype/use-components.md
@@ -76,4 +76,12 @@ Your page should now look like this:
 <figcaption class="govuk-body">Screenshot of how your prototype should look.</figcaption>
 </figure>
 
-[Next (add a textarea to question 2)](use-components-2)
+
+<nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+  <div class="govuk-pagination__next">
+    <a class="govuk-link govuk-pagination__link" href="use-components-2" rel="next"> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+      </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+      <span class="govuk-pagination__link-label">Add a textarea to question 2</span></a>
+  </div>
+</nav>


### PR DESCRIPTION
Use the GOVUK Frontend Pagination component

closes #119 

Since the deploy isnt working right now, the new links look like this:

<img width="873" alt="tutorial page with GOV.UK Design System Pagination Next link - it has a little arrow next to it" src="https://user-images.githubusercontent.com/1132904/207839796-ae40039c-8632-4ceb-bf0e-0c9517d137a8.png">
