### PR TITLE
Refactor code to render pages in docs app

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const path = require('path')
 
 const glob = require('glob')
+const matter = require('gray-matter')
 const request = require('supertest')
 const sass = require('sass')
 
@@ -222,7 +223,8 @@ describe('The Prototype Kit', () => {
     const markdownFiles = glob.sync('docs/*/documentation/**/*.md')
     it.each(markdownFiles)('%s has a title', (filepath) => {
       const file = readFile(filepath)
-      utils.getRenderOptions(file, filepath)
+      const parsedFile = matter(file)
+      expect(parsedFile.data.heading).toBeTruthy()
     })
   })
 })

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -68,6 +68,54 @@ describe('The Prototype Kit', () => {
     })
   })
 
+  describe('tutorials and examples page', () => {
+    it('should send a well formed response', async () => {
+      const response = await request(app).get('/docs/tutorials-and-examples/')
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('should return html file', async () => {
+      const response = await request(app).get('/docs/tutorials-and-examples/')
+      expect(response.type).toBe('text/html')
+    })
+
+    it('should redirect to /docs/tutorials-and-examples/ if .html given', async () => {
+      const response = await request(app).get('/docs/tutorials-and-examples.html')
+      expect(response.statusCode).toBe(302)
+      expect(response.get('location')).toMatch('/docs/tutorials-and-examples/')
+    })
+
+    it.skip('should redirect to /docs/tutorials-and-examples/ if no end slash is given', async () => {
+      const response = await request(app).get('/docs/tutorials-and-examples')
+      expect(response.statusCode).toBe(302)
+      expect(response.get('location')).toMatch('/docs/tutorials-and-examples/')
+    })
+  })
+
+  describe('getting started page', () => {
+    it('should send a well formed response', async () => {
+      const response = await request(app).get('/docs/install/getting-started/')
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('should return html file', async () => {
+      const response = await request(app).get('/docs/install/getting-started/')
+      expect(response.type).toBe('text/html')
+    })
+
+    it('should redirect to /docs/install/getting-started/ if .md given', async () => {
+      const response = await request(app).get('/docs/install/getting-started.md')
+      expect(response.statusCode).toBe(302)
+      expect(response.get('location')).toMatch('/docs/install/getting-started/')
+    })
+
+    it.skip('should redirect to /docs/install/getting-started/ if no end slash is given', async () => {
+      const response = await request(app).get('/docs/install/getting-started')
+      expect(response.statusCode).toBe(302)
+      expect(response.get('location')).toMatch('/docs/install/getting-started/')
+    })
+  })
+
   describe('search engine indexing', () => {
     it('should allow indexing of pages under /docs/', async () => {
       const response = await request(app).get('/docs/')

--- a/docs/v12/documentation/install/developer-install-instructions.md
+++ b/docs/v12/documentation/install/developer-install-instructions.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: Installation guide for advanced users
 caption: Install the Prototype Kit
 ---

--- a/docs/v12/documentation/install/install-the-kit.md
+++ b/docs/v12/documentation/install/install-the-kit.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: How to install the kit
 caption: Installation guide for new users
 ---

--- a/docs/v12/documentation/install/introduction.md
+++ b/docs/v12/documentation/install/introduction.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: Installation guide for new users
 caption: Install the Prototype Kit
 ---

--- a/docs/v12/documentation/install/requirements.md
+++ b/docs/v12/documentation/install/requirements.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: Prototype Kit requirements
 caption: Installation guide for new users
 ---

--- a/docs/v12/documentation/install/run-the-kit.md
+++ b/docs/v12/documentation/install/run-the-kit.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: How to run the kit
 caption: Installation guide for new users
 ---

--- a/docs/v12/documentation_routes.js
+++ b/docs/v12/documentation_routes.js
@@ -22,17 +22,6 @@ router.get('/', function (req, res) {
   }
 })
 
-router.get('/install', function (req, res) {
-  res.render('install')
-})
-
-// Pages in install folder are markdown
-router.get('/install/:page', function (req, res) {
-  var doc = fs.readFileSync(path.join(__dirname, '/documentation/install/', req.params.page + '.md'), 'utf8')
-  const renderOptions = utils.getRenderOptions(doc)
-  res.render('install_template', renderOptions)
-})
-
 // Redirect to download the current release zip from GitHub,
 // based on the version number from govuk-prototype-kit-version.json
 router.get('/download', function (req, res) {

--- a/docs/v12/documentation_routes.js
+++ b/docs/v12/documentation_routes.js
@@ -1,13 +1,6 @@
-// Core dependencies
-const fs = require('fs')
-const path = require('path')
-
 // NPM dependencies
 const express = require('express')
 const router = express.Router()
-
-// Local dependencies
-const utils = require('../../lib/utils')
 
 // version of Kit for docs
 const kitVersion = require('./govuk-prototype-kit-version').version
@@ -35,12 +28,6 @@ router.get('/install', function (req, res) {
 
 // Pages in install folder are markdown
 router.get('/install/:page', function (req, res) {
-  // If the link already has .md on the end (for GitHub docs)
-  // remove this when we render the page
-  if (req.params.page.slice(-3).toLowerCase() === '.md') {
-    req.params.page = req.params.page.slice(0, -3)
-  }
-  redirectMarkdown(req.params.page, res)
   var doc = fs.readFileSync(path.join(__dirname, '/documentation/install/', req.params.page + '.md'), 'utf8')
   const renderOptions = utils.getRenderOptions(doc)
   res.render('install_template', renderOptions)
@@ -103,13 +90,3 @@ router.get('/privacy-policy', function (req, res) {
 })
 
 module.exports = router
-
-// Strip off markdown extensions if present and redirect
-var redirectMarkdown = function (requestedPage, res) {
-  if (requestedPage.slice(-3).toLowerCase() === '.md') {
-    res.redirect(requestedPage.slice(0, -3))
-  }
-  if (requestedPage.slice(-9).toLowerCase() === '.markdown') {
-    res.redirect(requestedPage.slice(0, -9))
-  }
-}

--- a/docs/v13/documentation/install/create-a-prototype.md
+++ b/docs/v13/documentation/install/create-a-prototype.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: Create a prototype
 caption: Create a prototype
 ---

--- a/docs/v13/documentation/install/getting-started-advanced.md
+++ b/docs/v13/documentation/install/getting-started-advanced.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: Getting started - advanced guide
 caption: Create a prototype
 ---

--- a/docs/v13/documentation/install/getting-started.md
+++ b/docs/v13/documentation/install/getting-started.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: Getting started with the Prototype Kit
 caption: Create a prototype
 ---

--- a/docs/v13/documentation/install/how-to-run-the-kit.md
+++ b/docs/v13/documentation/install/how-to-run-the-kit.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: How to run the kit
 caption: Create a prototype for new users
 ---

--- a/docs/v13/documentation/install/requirements.md
+++ b/docs/v13/documentation/install/requirements.md
@@ -1,4 +1,5 @@
 ---
+layout: install_template.html
 heading: Prototype Kit requirements
 caption: Create a prototype for new users
 ---

--- a/docs/v13/documentation_routes.js
+++ b/docs/v13/documentation_routes.js
@@ -1,13 +1,6 @@
-// Core dependencies
-const fs = require('fs')
-const path = require('path')
-
 // NPM dependencies
 const express = require('express')
 const router = express.Router()
-
-// Local dependencies
-const utils = require('../../lib/utils')
 
 // version of Kit for docs
 const kitVersion = require('./govuk-prototype-kit-version').version
@@ -35,12 +28,6 @@ router.get('/install', function (req, res) {
 
 // Pages in install folder are markdown
 router.get('/install/:page', function (req, res) {
-  // If the link already has .md on the end (for GitHub docs)
-  // remove this when we render the page
-  if (req.params.page.slice(-3).toLowerCase() === '.md') {
-    req.params.page = req.params.page.slice(0, -3)
-  }
-  redirectMarkdown(req.params.page, res)
   var doc = fs.readFileSync(path.join(__dirname, '/documentation/install/', req.params.page + '.md'), 'utf8')
   const renderOptions = utils.getRenderOptions(doc)
   res.render('install_template', renderOptions)
@@ -93,13 +80,3 @@ router.get('/examples/pass-data', function (req, res) {
 })
 
 module.exports = router
-
-// Strip off markdown extensions if present and redirect
-var redirectMarkdown = function (requestedPage, res) {
-  if (requestedPage.slice(-3).toLowerCase() === '.md') {
-    res.redirect(requestedPage.slice(0, -3))
-  }
-  if (requestedPage.slice(-9).toLowerCase() === '.markdown') {
-    res.redirect(requestedPage.slice(0, -9))
-  }
-}

--- a/docs/v13/documentation_routes.js
+++ b/docs/v13/documentation_routes.js
@@ -22,17 +22,6 @@ router.get('/', function (req, res) {
   }
 })
 
-router.get('/install', function (req, res) {
-  res.render('install')
-})
-
-// Pages in install folder are markdown
-router.get('/install/:page', function (req, res) {
-  var doc = fs.readFileSync(path.join(__dirname, '/documentation/install/', req.params.page + '.md'), 'utf8')
-  const renderOptions = utils.getRenderOptions(doc)
-  res.render('install_template', renderOptions)
-})
-
 // Examples - examples post here
 router.post('/tutorials-and-examples', function (req, res) {
   res.redirect('tutorials-and-examples')

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,0 +1,45 @@
+const fs = require('fs')
+const path = require('path')
+
+const matter = require('gray-matter')
+const { marked } = require('marked')
+
+// Tweak the Markdown renderer
+const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()
+
+marked.use({
+  renderer: {
+    code (code, infostring, escaped) {
+      let rawHtml = defaultMarkedRenderer.code(code, infostring, escaped)
+      // Add a tabindex to the <pre> element, to allow keyboard focus / scrolling
+      rawHtml = rawHtml.replace('<pre>', '<pre tabindex="0">')
+      return rawHtml
+    }
+  }
+})
+
+exports.isMdView = function (mdDir, name) {
+  const reqPath = path.join(mdDir, name + '.md')
+  return fs.existsSync(reqPath)
+}
+
+exports.markdownEngine = (nunjucksEnv) => {
+  return (filePath, options, callback) => {
+    fs.readFile(filePath, (err, fileContents) => {
+      if (err) return callback(err)
+      const parsedFile = matter(fileContents)
+      if (parsedFile.data.heading === undefined) {
+        throw new Error(`${filePath} does not have a heading in its frontmatter`)
+      }
+      const layout = parsedFile.data.layout || 'documentation_template.html'
+      marked(parsedFile.content, (err, html) => {
+        if (err) return callback(err)
+        nunjucksEnv.render(
+          layout,
+          { ...options, ...parsedFile.data, document: html },
+          callback
+        )
+      })
+    })
+  }
+}

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+const fs = require('fs')
+
+const render = require('./render')
+
+describe('markdownEngine', () => {
+  let md
+
+  beforeEach(() => {
+    jest.spyOn(fs, 'readFile').mockImplementation(
+      (filePath, callback) => { callback(null, md) }
+    )
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('uses front matter to generate heading', () => {
+    md = '---\n' +
+      'heading: Share usage data\n' +
+      '---\n' +
+      'This is some content.'
+
+    const mockRender = jest.fn()
+    render.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
+
+    const received = mockRender.mock.lastCall[1]
+
+    expect(received).toHaveProperty('heading')
+    expect(received.heading).toEqual('Share usage data')
+  })
+
+  it('uses front matter to generate title', () => {
+    md = '---\n' +
+      'heading: Share usage data\n' +
+      'title: Share usage data\n' +
+      '---\n' +
+      'This is some content.'
+
+    const mockRender = jest.fn()
+    render.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
+
+    const received = mockRender.mock.lastCall[1]
+
+    expect(received).toHaveProperty('title')
+    expect(received.title).toEqual('Share usage data')
+  })
+
+  it('throws an error if front matter title is not present', () => {
+    md = '# This is a plain heading'
+
+    const expectedError = new Error('docs/documentation/this-is-a-plain-heading.md does not have a heading in its frontmatter')
+
+    expect(() => {
+      render.markdownEngine({ render: jest.fn() })(
+        'docs/documentation/this-is-a-plain-heading.md', {}, jest.fn()
+      )
+    }).toThrow(expectedError)
+  })
+
+  it('allows keyboard focus for code blocks', () => {
+    md = '---\n' +
+      'heading: test\n' +
+      '---\n' +
+      '```\n' +
+      'This is a code block\n' +
+      '```\n'
+
+    const mockRender = jest.fn()
+    render.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
+
+    const { document } = mockRender.mock.lastCall[1]
+
+    expect(document).toContain('<pre tabindex="0">')
+  })
+})

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -152,69 +152,30 @@ exports.forceHttps = function (req, res, next) {
   next()
 }
 
-// Try to match a request to a template, for example a request for /test
-// would look for /app/views/test.html
-// and /app/views/test/index.html
-
-function renderPath (path, res, next) {
-  // Try to render the path
-  res.render(path, function (error, html) {
-    if (!error) {
-      // Success - send the response
-      res.set({ 'Content-type': 'text/html; charset=utf-8' })
-      res.end(html)
-      return
-    }
-    if (!error.message.startsWith('template not found')) {
-      // We got an error other than template not found - call next with the error
-      next(error)
-      return
-    }
-    if (!path.endsWith('/index')) {
-      // Maybe it's a folder - try to render [path]/index.html
-      renderPath(path + '/index', res, next)
-      return
-    }
-    // We got template not found both times - call next to trigger the 404 page
-    next()
-  })
+exports.isMdView = function (mdDir, name) {
+  const reqPath = path.join(mdDir, name + '.md')
+  return fs.existsSync(reqPath)
 }
 
-exports.matchRoutes = function (req, res, next) {
-  var path = req.path
-
-  // Remove the first slash, render won't work with it
-  path = path.substr(1)
-
-  // If it's blank, render the root index
-  if (path === '') {
-    path = 'index'
+exports.markdownEngine = (nunjucksEnv) => {
+  return (filePath, options, callback) => {
+    fs.readFile(filePath, (err, fileContents) => {
+      if (err) return callback(err)
+      const parsedFile = matter(fileContents)
+      if (parsedFile.data.heading === undefined) {
+        throw new Error(`${filePath} does not have a heading in its frontmatter`)
+      }
+      const layout = parsedFile.data.layout || 'documentation_template.html'
+      marked(parsedFile.content, (err, html) => {
+        if (err) return callback(err)
+        nunjucksEnv.render(
+          layout,
+          { ...options, ...parsedFile.data, document: html },
+          callback
+        )
+      })
+    })
   }
-
-  renderPath(path, res, next)
-}
-
-// Try to match a request to a Markdown file and render it
-exports.matchMdRoutes = function (mdDir, req, res) {
-  const reqPath = path.join(mdDir, req.params[0] + '.md')
-  if (fs.existsSync(reqPath, 'utf8')) {
-    const doc = fs.readFileSync(reqPath, 'utf8')
-    const renderOptions = module.exports.getRenderOptions(doc, mdDir + req.params[0])
-    res.render('documentation_template', renderOptions)
-    return true
-  }
-  return false
-}
-
-exports.getRenderOptions = function (document, docPath) {
-  const parsedFile = matter(document)
-  if (parsedFile.data.heading === undefined) {
-    throw new Error(`${docPath} does not have a heading in its frontmatter`)
-  }
-
-  const html = marked(parsedFile.content)
-
-  return { document: html, ...parsedFile.data }
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,12 @@
 // Core dependencies
 const crypto = require('crypto')
 const fs = require('fs')
+const path = require('path')
 
 // NPM dependencies
 const { get: getKeypath } = require('lodash')
-const { marked } = require('marked')
-const path = require('path')
 const portScanner = require('portscanner')
 const inquirer = require('inquirer')
-const matter = require('gray-matter')
 
 // Are we running on Glitch.com?
 const onGlitch = function () {
@@ -31,20 +29,6 @@ exports.getNodeEnv = function () {
   const env = (process.env.NODE_ENV || glitchEnv || 'development').toLowerCase()
   return env
 }
-
-// Tweak the Markdown renderer
-const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()
-
-marked.use({
-  renderer: {
-    code (code, infostring, escaped) {
-      let rawHtml = defaultMarkedRenderer.code(code, infostring, escaped)
-      // Add a tabindex to the <pre> element, to allow keyboard focus / scrolling
-      rawHtml = rawHtml.replace('<pre>', '<pre tabindex="0">')
-      return rawHtml
-    }
-  }
-})
 
 // Require core filters and then add the methods to Nunjucks environment
 exports.addNunjucksFilters = function (env) {
@@ -150,32 +134,6 @@ exports.forceHttps = function (req, res, next) {
   // Mark proxy as secure (allows secure cookies)
   req.connection.proxySecure = true
   next()
-}
-
-exports.isMdView = function (mdDir, name) {
-  const reqPath = path.join(mdDir, name + '.md')
-  return fs.existsSync(reqPath)
-}
-
-exports.markdownEngine = (nunjucksEnv) => {
-  return (filePath, options, callback) => {
-    fs.readFile(filePath, (err, fileContents) => {
-      if (err) return callback(err)
-      const parsedFile = matter(fileContents)
-      if (parsedFile.data.heading === undefined) {
-        throw new Error(`${filePath} does not have a heading in its frontmatter`)
-      }
-      const layout = parsedFile.data.layout || 'documentation_template.html'
-      marked(parsedFile.content, (err, html) => {
-        if (err) return callback(err)
-        nunjucksEnv.render(
-          layout,
-          { ...options, ...parsedFile.data, document: html },
-          callback
-        )
-      })
-    })
-  }
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+const fs = require('fs')
 
 const nunjucks = require('nunjucks')
 
@@ -106,51 +107,74 @@ describe('checked', () => {
   })
 })
 
-describe('getRenderOptions', () => {
+describe('markdownEngine', () => {
+  let md
+
+  beforeEach(() => {
+    jest.spyOn(fs, 'readFile').mockImplementation(
+      (filePath, callback) => { callback(null, md) }
+    )
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('uses front matter to generate heading', () => {
-    const md = '---\n' +
+    md = '---\n' +
       'heading: Share usage data\n' +
       '---\n' +
       'This is some content.'
 
-    const received = utils.getRenderOptions(md)
+    const mockRender = jest.fn()
+    utils.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
+
+    const received = mockRender.mock.lastCall[1]
 
     expect(received).toHaveProperty('heading')
     expect(received.heading).toEqual('Share usage data')
   })
 
   it('uses front matter to generate title', () => {
-    const md = '---\n' +
+    md = '---\n' +
       'heading: Share usage data\n' +
       'title: Share usage data\n' +
       '---\n' +
       'This is some content.'
 
-    const received = utils.getRenderOptions(md)
+    const mockRender = jest.fn()
+    utils.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
+
+    const received = mockRender.mock.lastCall[1]
 
     expect(received).toHaveProperty('title')
     expect(received.title).toEqual('Share usage data')
   })
 
   it('throws an error if front matter title is not present', () => {
-    const md = '# This is a plain heading'
+    md = '# This is a plain heading'
 
     const expectedError = new Error('docs/documentation/this-is-a-plain-heading.md does not have a heading in its frontmatter')
 
     expect(() => {
-      utils.getRenderOptions(md, 'docs/documentation/this-is-a-plain-heading.md')
+      utils.markdownEngine({ render: jest.fn() })(
+        'docs/documentation/this-is-a-plain-heading.md', {}, jest.fn()
+      )
     }).toThrow(expectedError)
   })
 
   it('allows keyboard focus for code blocks', () => {
-    const md = '---\n' +
+    md = '---\n' +
       'heading: test\n' +
       '---\n' +
       '```\n' +
       'This is a code block\n' +
       '```\n'
 
-    const { document } = utils.getRenderOptions(md)
+    const mockRender = jest.fn()
+    utils.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
+
+    const { document } = mockRender.mock.lastCall[1]
 
     expect(document).toContain('<pre tabindex="0">')
   })

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -1,6 +1,4 @@
 /* eslint-env jest */
-const fs = require('fs')
-
 const nunjucks = require('nunjucks')
 
 const utils = require('./utils.js')
@@ -104,79 +102,6 @@ describe('checked', () => {
   it('allows deep access using dot notation (undocumented)', () => {
     ctx.data.foo = { bar: 'baz' }
     expect(checked('foo.bar', 'baz')).toBe('checked')
-  })
-})
-
-describe('markdownEngine', () => {
-  let md
-
-  beforeEach(() => {
-    jest.spyOn(fs, 'readFile').mockImplementation(
-      (filePath, callback) => { callback(null, md) }
-    )
-  })
-
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
-  it('uses front matter to generate heading', () => {
-    md = '---\n' +
-      'heading: Share usage data\n' +
-      '---\n' +
-      'This is some content.'
-
-    const mockRender = jest.fn()
-    utils.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
-
-    const received = mockRender.mock.lastCall[1]
-
-    expect(received).toHaveProperty('heading')
-    expect(received.heading).toEqual('Share usage data')
-  })
-
-  it('uses front matter to generate title', () => {
-    md = '---\n' +
-      'heading: Share usage data\n' +
-      'title: Share usage data\n' +
-      '---\n' +
-      'This is some content.'
-
-    const mockRender = jest.fn()
-    utils.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
-
-    const received = mockRender.mock.lastCall[1]
-
-    expect(received).toHaveProperty('title')
-    expect(received.title).toEqual('Share usage data')
-  })
-
-  it('throws an error if front matter title is not present', () => {
-    md = '# This is a plain heading'
-
-    const expectedError = new Error('docs/documentation/this-is-a-plain-heading.md does not have a heading in its frontmatter')
-
-    expect(() => {
-      utils.markdownEngine({ render: jest.fn() })(
-        'docs/documentation/this-is-a-plain-heading.md', {}, jest.fn()
-      )
-    }).toThrow(expectedError)
-  })
-
-  it('allows keyboard focus for code blocks', () => {
-    md = '---\n' +
-      'heading: test\n' +
-      '---\n' +
-      '```\n' +
-      'This is a code block\n' +
-      '```\n'
-
-    const mockRender = jest.fn()
-    utils.markdownEngine({ render: mockRender })(undefined, {}, jest.fn())
-
-    const { document } = mockRender.mock.lastCall[1]
-
-    expect(document).toContain('<pre tabindex="0">')
   })
 })
 

--- a/server.js
+++ b/server.js
@@ -219,7 +219,16 @@ app.get(/\.html?$/i, function (req, res) {
   var path = req.path
   var parts = path.split('.')
   parts.pop()
-  path = parts.join('.')
+  path = parts.join('.') + '/'
+  res.redirect(path)
+})
+
+// Strip .md if provided
+app.get(/\.md$/i, function (req, res) {
+  var path = req.path
+  var parts = path.split('.')
+  parts.pop()
+  path = parts.join('.') + '/'
   res.redirect(path)
 })
 

--- a/server.js
+++ b/server.js
@@ -246,13 +246,6 @@ app.use(function (req, res, next) {
   next(err)
 })
 
-// Display error
-app.use(function (err, req, res, next) {
-  console.error(err.message)
-  res.status(err.status || 500)
-  res.send(err.message)
-})
-
 console.log('\nGOV.UK Prototype Kit docs')
 
 module.exports = app

--- a/server.js
+++ b/server.js
@@ -15,8 +15,9 @@ const MemoryStore = require('memorystore')(session)
 dotenv.config()
 
 // Local dependencies
-const utils = require('./lib/utils.js')
-const extensions = require('./lib/extensions/extensions.js')
+const extensions = require('./lib/extensions/extensions')
+const utils = require('./lib/utils')
+const render = require('./lib/render')
 const { projectDir } = require('./lib/path-utils')
 
 const app = express()
@@ -152,7 +153,7 @@ function createDocumentationApp (docsDir, { latest = false, locals = {} }) {
   documentationApp.engine('.html', (filePath, options, callback) => {
     nunjucksDocumentationEnv.render(filePath, options, callback)
   })
-  documentationApp.engine('.md', utils.markdownEngine(nunjucksDocumentationEnv))
+  documentationApp.engine('.md', render.markdownEngine(nunjucksDocumentationEnv))
   documentationApp.set('view engine', 'html')
 
   // Automatically store all data users enter
@@ -184,7 +185,7 @@ function createDocumentationApp (docsDir, { latest = false, locals = {} }) {
     if (name.startsWith('/')) { name = name.slice(1) }
     if (name.endsWith('/')) { name = name.slice(0, -1) }
 
-    if (utils.isMdView(docsMdDir, name)) {
+    if (render.isMdView(docsMdDir, name)) {
       res.render(path.join(docsMdDir, name + '.md'))
     } else {
       res.render(name)


### PR DESCRIPTION
When hooking Nunjucks into Express, it changes some core functionality [[1]]. This makes it hard to use other template engines at the same time as Nunjucks.

This PR changes our code so that Nunjucks is integrated in a way that is more similar to how Express expects. This then lets us hook the Markdown renderer a simpler fashion, so we can remove some other parts of our our code.

We also add support for specifying layout template in Markdown page frontmatter, so we no longer need to write a route function to handle Markdown pages which use a different layout template to the default. We call the frontmatter property `layout`, similar to what Eleventy does [[2]]. 

[1]: https://github.com/mozilla/nunjucks/blob/fd500902d7c88672470c87170796de52fc0f791a/nunjucks/src/express-app.js
[2]: https://www.11ty.dev/docs/layouts/