### PR TITLE
Improve windows guidance

### DIFF
--- a/docs/v13/documentation/install/node.md.njk
+++ b/docs/v13/documentation/install/node.md.njk
@@ -1,0 +1,50 @@
+---
+layout: install_template.html
+heading: Install Node.js
+caption: Create a prototype for new users
+---
+
+The kit is designed to work with Node.js version 18 LTS. The kit works with any 18.x.x version.
+
+### Check if you have Node.js
+
+In terminal (or Git Bash in Windows):
+```
+node --version
+```
+If it says `command not found` or `Error 0x2 starting node.exe --version` you don’t have Node and will need to download and install it.
+
+If the version number starts with 18 you have the correct version installed.
+
+If it starts with another number you need to download and install version 18.
+
+### Download and install Node.js
+
+#### Mac and Windows
+
+[Download version 18 from the Node.js website.](https://nodejs.org/en/)
+
+Run the installer with all default options.
+
+#### Linux
+
+[Follow the Linux instructions on the Node.js. website.](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) Make sure you get version 18.
+
+### Once Node is installed
+
+You’ll need to quit and restart the terminal to be able to use Node for the first time.
+
+To check it is installed correctly you can again run:
+```
+node --version
+```
+
+If it’s installed correctly it should show a number starting with 18.
+
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{{ govukPagination({
+  next: {
+    labelText: "Create a prototype",
+    href: "./create-a-prototype"
+  }
+}) }}

--- a/docs/v13/documentation/install/requirements.md.njk
+++ b/docs/v13/documentation/install/requirements.md.njk
@@ -18,17 +18,21 @@ GDS staff can install the software themselves with the Self Service app.
 You'll need:
 
 * Node.js 18.x.x
-* Git Bash (if you're using Windows, see below)
+* A terminal or Git Bash if you're using Windows, see below
 
 ## Terminal
 
 You'll need a terminal application to install, start and stop the kit. Using a terminal is sometimes called ‘using the command line’.
 
-### Mac users
+### Mac and Linux
 
-Macs come with a terminal application already. It’s located in the `Utilities` folder in the `Applications` folder. You can also find it using spotlight (magnifying glass icon in the top right) and typing 'terminal'.
+Macs and Linux come with a terminal application already.
 
-### Windows users
+On a Mac it’s located in the `Utilities` folder in the `Applications` folder. You can also find it using spotlight (magnifying glass icon in the top right) and typing 'terminal'.
+
+Next, [install Node.js](node)
+
+### Windows
 
 This guide will use `Git Bash` as a terminal instead of the existing `CMD` application. Git Bash is more fully featured and uses the same commands as Mac and Linux, so instructions in this guide work for all.
 
@@ -41,51 +45,8 @@ Installing `Git Bash` installs 2 things for you:
 
 Download [Git Bash (direct download)](https://git-scm.com/download/win).
 
-Install with all the default options.
+When you install, on the screen **Choosing the default editor used by Git** select **Use Nano editor by default** (you may need to scroll the options to see it).
 
-## Node.js version 18 LTS
+On all other screens, continue with the default options.
 
-The kit is designed to work with Node.js version 18 LTS. The kit works with any 18.x.x version.
-
-### Check if you have Node.js
-
-In terminal (Git Bash in Windows):
-```
-node --version
-```
-If it says `command not found` or `Error 0x2 starting node.exe --version` you don’t have Node and will need to download and install it.
-
-If the version number starts with 18 you have the correct version installed.
-
-If it says another number such as `0.12` or `5.x.x`, you need to download and install version 18.
-
-### Download and install Node.js
-
-#### Mac and Windows users
-
-[Download version 18 from the Node.js website.](https://nodejs.org/en/)
-
-Run the installer with all default options.
-
-#### Linux users
-
-[Follow the Linux instructions on the Node.js. website.](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) Make sure you get version 18.
-
-### Once Node is installed
-
-You’ll need to quit and restart the terminal to be able to use Node for the first time.
-
-To check it is installed correctly you can again run:
-```
-node --version
-```
-
-If it’s installed correctly it should show a number starting with 18.
-
-{% from "govuk/components/pagination/macro.njk" import govukPagination %}
-{{ govukPagination({
-  next: {
-    labelText: "Create a prototype",
-    href: "create-a-prototype"
-  }
-}) }}
+Next, [install Node.js](node)


### PR DESCRIPTION
 - Adds a step to change the default editor from Vim to Nano (it's very hard for new users to use Vim)
 - Makes the Mac/Windows flow simpler - we know from research that it was confusing having a page split into sections for Mac/Windows and another section for all users
 - simplifies the Node guidance slightly