### PR TITLE
Update templates and clean up

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -71,25 +71,25 @@ describe('The Prototype Kit', () => {
 
   describe('tutorials and examples page', () => {
     it('should send a well formed response', async () => {
-      const response = await request(app).get('/docs/tutorials-and-examples/')
+      const response = await request(app).get('/docs/tutorials-and-guides/')
       expect(response.statusCode).toBe(200)
     })
 
     it('should return html file', async () => {
-      const response = await request(app).get('/docs/tutorials-and-examples/')
+      const response = await request(app).get('/docs/tutorials-and-guides/')
       expect(response.type).toBe('text/html')
     })
 
-    it('should redirect to /docs/tutorials-and-examples/ if .html given', async () => {
-      const response = await request(app).get('/docs/tutorials-and-examples.html')
+    it('should redirect to /docs/tutorials-and-guides/ if .html given', async () => {
+      const response = await request(app).get('/docs/tutorials-and-guides.html')
       expect(response.statusCode).toBe(302)
-      expect(response.get('location')).toMatch('/docs/tutorials-and-examples/')
+      expect(response.get('location')).toMatch('/docs/tutorials-and-guides/')
     })
 
-    it.skip('should redirect to /docs/tutorials-and-examples/ if no end slash is given', async () => {
-      const response = await request(app).get('/docs/tutorials-and-examples')
+    it.skip('should redirect to /docs/tutorials-and-guides/ if no end slash is given', async () => {
+      const response = await request(app).get('/docs/tutorials-and-guides')
       expect(response.statusCode).toBe(302)
-      expect(response.get('location')).toMatch('/docs/tutorials-and-examples/')
+      expect(response.get('location')).toMatch('/docs/tutorials-and-guides/')
     })
   })
 

--- a/docs/v13/documentation/accessibility.md
+++ b/docs/v13/documentation/accessibility.md
@@ -48,7 +48,7 @@ The test was carried out by the GOV.UK Prototype Kit team.
 The GOV.UK Prototype Kit team tested a sample of pages to cover the different content types in the Prototype Kit website. They were:
 
 - [the homepage](./)
-- [the tutorials and templates page](./tutorials-and-examples)
+- [the tutorials and guides page](./tutorials-and-guides)
 - [the tutorial pages](./make-first-prototype/start)
 - [the guide pages](./publishing-on-heroku)
 - [the example pages](./examples/pass-data)

--- a/docs/v13/documentation/create-pages-from-templates.md.njk
+++ b/docs/v13/documentation/create-pages-from-templates.md.njk
@@ -25,17 +25,17 @@ The Prototype Kit also has GOV.UK publishing templates for:
 
 * Mainstream guide
 * Start page
-* Step by step navigation
-* Start page with step by step
 
 You cannot alter the design of the GOV.UK publishing templates. They are to help you prototype realistic journeys connecting your service with the GOV.UK website.
 
 Read the guidance for mainstream guides in [Content design: planning, writing and managing content](https://www.gov.uk/guidance/content-design).
 
-Read the [Start using a service guidance](https://design-system.service.gov.uk/patterns/start-using-a-service) and the [step by step navigation guidance](https://design-system.service.gov.uk/patterns/step-by-step-navigation) to learn how to make these pages live for your service.
+Read the [Start using a service guidance](https://design-system.service.gov.uk/patterns/start-using-a-service) to learn how to get a start page for your service.
 
-## Using step by step navigation
+## Step by step navigation
 
-Step by step navigation is for a page outside your transactional service. It’s in the Prototype Kit so you can prototype your journeys for testing. Step by step is available as a plugin.
+Step by step navigation is for a page outside your transactional service. It’s available as a plugin for the Prototype Kit so you can prototype your journeys for testing. To install, go to the **Plugins** section of **Manage your prototype**.
+
+Read the [step by step navigation guidance](https://design-system.service.gov.uk/patterns/step-by-step-navigation).
 
 {% include "_new-version-inset-text.njk" %}

--- a/docs/v13/documentation_routes.js
+++ b/docs/v13/documentation_routes.js
@@ -23,8 +23,8 @@ router.get('/', function (req, res) {
 })
 
 // Examples - examples post here
-router.post('/tutorials-and-examples', function (req, res) {
-  res.redirect('tutorials-and-examples')
+router.post('/tutorials-and-guides', function (req, res) {
+  res.redirect('tutorials-and-guides')
 })
 
 // Example routes
@@ -74,6 +74,10 @@ router.get('/install/introduction', function (req, res) {
 
 router.get('/install/developer-install-instructions', function (req, res) {
   res.redirect('/docs/install/getting-started-advanced')
+})
+
+router.get('/tutorials-and-examples', function (req, res) {
+  res.redirect('/docs/tutorials-and-guides')
 })
 
 module.exports = router

--- a/docs/v13/views/documentation_template.html
+++ b/docs/v13/views/documentation_template.html
@@ -12,8 +12,8 @@
         href: baseUrl
       },
       {
-        text: "Tutorials and templates",
-        href: baseUrl + "/tutorials-and-examples"
+        text: "Tutorials and guides",
+        href: baseUrl + "/tutorials-and-guides"
       }
     ]
   }) }}

--- a/docs/v13/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/v13/views/examples/pass-data/vehicle-check-answers.html
@@ -65,8 +65,8 @@
       </dl>
 
       <p>
-        <a href="{{baseUrl}}/tutorials-and-examples">
-          Return to tutorials and templates
+        <a href="{{baseUrl}}/tutorials-and-guides">
+          Return to tutorials and guides
         </a>
       </p>
 

--- a/docs/v13/views/includes/breadcrumb_examples.html
+++ b/docs/v13/views/includes/breadcrumb_examples.html
@@ -4,7 +4,7 @@
       <a class="govuk-breadcrumbs__link" href="{{ baseUrl }}/">GOV.UK Prototype Kit</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="{{ baseUrl }}/tutorials-and-examples">Tutorials and templates</a>
+      <a class="govuk-breadcrumbs__link" href="{{ baseUrl }}/tutorials-and-guides">Tutorials and guides</a>
     </li>
   </ol>
 </div>

--- a/docs/v13/views/index.html
+++ b/docs/v13/views/index.html
@@ -42,9 +42,9 @@ GOV.UK Prototype Kit
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 
-      <h2 class="govuk-heading-m"><a href="./tutorials-and-examples" data-htutorials="Tutorials and templates">Tutorials and templates</a></h2>
+      <h2 class="govuk-heading-m"><a href="./tutorials-and-guides" data-htutorials="Tutorials and guides">Tutorials and guides</a></h2>
       <p>
-        Tutorials, examples and templates.
+        Tutorials, examples and guides.
       </p>
 
     </div>

--- a/docs/v13/views/layout.html
+++ b/docs/v13/views/layout.html
@@ -44,10 +44,10 @@
         }
       },
       {
-        href: baseUrl + "/tutorials-and-examples",
-        text: "Tutorials and templates",
+        href: baseUrl + "/tutorials-and-guides",
+        text: "Tutorials and guides",
         attributes: {
-          "data-tutorials": "Tutorials and templates"
+          "data-tutorials": "Tutorials and guides"
         }
       },
       {

--- a/docs/v13/views/tutorials-and-guides.html
+++ b/docs/v13/views/tutorials-and-guides.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Tutorials and templates – GOV.UK Prototype Kit
+  Tutorials and guides – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -17,7 +17,7 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">Tutorials and templates</h1>
+  <h1 class="govuk-heading-xl">Tutorials and guides</h1>
 
   <div class="govuk-grid-row">
 
@@ -142,34 +142,6 @@
       </ul>
     </div>
   </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">Page templates</h2>
-      <p>
-        You can find templates on the <strong>Templates</strong> page from <strong>Manage your Prototype</strong>.
-      </p>
-      <p>
-        You cannot adjust the design of these pages, but you can use them to help
-        you prototype realistic journeys connecting your service with GOV.UK content.
-      </p>
-      <p>
-        Check the <a href="https://www.gov.uk/guidance/content-design/planning-content">guidance for mainstream guides in the Content design: planning, writing and managing content manual</a>.
-      </p>
-      <p>
-        Read the <a href="https://design-system.service.gov.uk/patterns/start-using-a-service/">Help users start using a service</a> guidance and the <a href="https://design-system.service.gov.uk/patterns/step-by-step-navigation/">Step by step navigation</a> guidance to learn how to make these pages live for your service.
-      </p>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m">When not to use step by step navigation</h3>
-      <p>
-      Remember that step by step navigation is not for use within transactional services. We have included it in the Prototype Kit only so you can prototype your journeys. Unlike most other components and patterns in the Design System, we do not provide the code for step by step navigation in `govuk-frontend`.
-    </p>
-  </div>
-</div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
- De-duplicate template guidance
- Clarify guidance on Step by step templates
- Rename Tutorials and templates page to Tutorials and guides now it has no templates
- Change the url from `tutorials-and-examples` to ``tutorials-and-guides` to match the name
- Add a redirect for the changed url
- Fixed tests
 
closes https://github.com/alphagov/govuk-prototype-kit-docs/issues/106