### PR TITLE
Google site verification for Search Console

### DIFF
--- a/docs/v13/views/index.html
+++ b/docs/v13/views/index.html
@@ -4,6 +4,11 @@
 GOV.UK Prototype Kit
 {% endblock %}
 
+{% block head %}
+  {{ super() }}
+  <meta name="google-site-verification" content="aKquocaMh1sxbLsNwlQpAzloSx0N0V9gQ9ExEaz4h6g" />
+{% endblock %}
+
 {% block content %}
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
Add a meta tag to home page for verifying our site on Google Search Console

 - part of https://github.com/alphagov/govuk-prototype-kit/issues/1136