### PR TITLE
fix confusion around "2 paragraphs"

### DIFF
--- a/docs/v13/documentation/make-first-prototype/link-pages-together.md.njk
+++ b/docs/v13/documentation/make-first-prototype/link-pages-together.md.njk
@@ -21,8 +21,8 @@ Links normally appear as text with underlines. We make **Start now** look like a
 ## Link question 1 to question 2
 
 1. Open `juggling-balls.html` in your `app/views` folder.
-2. Find the line `<form class="form" action="/url/of/next/page" method="post">`.
-3. Change the value of the `action` attribute from `/url/of/next/page` to `/juggling-trick`.
+2. Find the line `<form class="form" action="/path/of/next/page" method="post">`.
+3. Change the value of the `action` attribute from `/path/of/next/page` to `/juggling-trick`.
 
 [Go to http://localhost:3000/juggling-balls](http://localhost:3000/juggling-balls) and select **Continue** to check the button works.
 
@@ -31,8 +31,8 @@ This time it's a real HTML button, not a link. Buttons submit form data - the UR
 ## Link question 2 to your 'Check answers' page
 
 1. Open `juggling-trick.html` in your `app/views` folder.
-2. Find the line `<form class="form" action="/url/of/next/page" method="post">`.
-3. Change the value of the `action` attribute from `/url/of/next/page` to `/check-answers`.
+2. Find the line `<form class="form" action="/path/of/next/page" method="post">`.
+3. Change the value of the `action` attribute from `/path/of/next/page` to `/check-answers`.
 
 [Go to http://localhost:3000/juggling-trick](http://localhost:3000/juggling-trick) and select **Continue** to check the button works.
 

--- a/docs/v13/documentation/make-first-prototype/use-components-2.md.njk
+++ b/docs/v13/documentation/make-first-prototype/use-components-2.md.njk
@@ -6,7 +6,14 @@ caption: Build a basic prototype
 1. Go to the [textarea page of the Design System](https://design-system.service.gov.uk/components/textarea/).
 2. Select the **Nunjucks** tab, then **Copy code**.
 3. Open `juggling-trick.html` in your `app/views` folder.
-4. Replace the 2 example `<p>...</p>` paragraphs with the code you copied.
+4. Replace this paragraph with the code you copied:
+```
+<p>
+  [Insert question content here - see the
+  <a href="https://design-system.service.gov.uk">GOV.UK Design System</a>
+  for examples]
+</p>
+```
 5. Delete the old `<h1>` tag with "What is your most impressive juggling trick?" (again the example code comes with an accessible heading for the question).
 
 ### Customise the example code

--- a/docs/v13/documentation/make-first-prototype/use-components.md.njk
+++ b/docs/v13/documentation/make-first-prototype/use-components.md.njk
@@ -18,8 +18,15 @@ In the Design System, components have both Nunjucks and HTML example code. Eithe
 1. Go to the [radios component in the Design System](https://design-system.service.gov.uk/components/radios/).
 2. Select the **Nunjucks** tab under the first example, then **Copy code**.
 3. Open `juggling-balls.html` in your `app/views` folder.
-4. Replace the 2 example `<p>...</p>` paragraphs with the code you copied.
-5. The example comes with a heading that is connected to the answers for accessibility, so delete the old `<h1>` tag with "How many balls can you juggle?".
+4. Replace this paragraph with the code you copied:
+```
+<p>
+  [Insert question content here - see the
+  <a href="https://design-system.service.gov.uk">GOV.UK Design System</a>
+  for examples]
+</p>
+```
+5. The example code comes with a heading that is connected to the answers for accessibility, so delete the old `<h1>` tag with "How many balls can you juggle?".
 
 ### Customise the example code
 


### PR DESCRIPTION
Related issue:
 - https://github.com/alphagov/govuk-prototype-kit/issues/874

(Relies on a change to the templates to be released first: https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/7)

Changes:

 - refers to replace paragraph instead of 2 paragraphs, with full sample code
 - refers to 'path' not 'url' for consistency