### PR TITLE
Fixes

### DIFF
--- a/docs/v13/documentation/make-first-prototype/create-pages.md.njk
+++ b/docs/v13/documentation/make-first-prototype/create-pages.md.njk
@@ -5,7 +5,9 @@ caption: Build a basic prototype
 
 You can create pages by using the templates that come with the Prototype Kit.
 
-In your browser go to the **Manage you prototype** page: http://localhost/manage-prototype. There is also a link to this page in the footer of your prototype.
+In your browser go to the **Manage your prototype** page: <a href="http://localhost:3000/manage-prototype" rel="noreferrer noopener" target="_blank">http://localhost:3000/manage-prototype (opens in new tab)</a>. 
+
+There is also a link to this page in the footer of your prototype.
 
 In the navigation menu, go to the **Templates** section.
 

--- a/docs/v13/documentation/make-first-prototype/link-pages-together.md.njk
+++ b/docs/v13/documentation/make-first-prototype/link-pages-together.md.njk
@@ -11,8 +11,8 @@ To take users from one page to another, you can use either:
 ## Link your start page to question 1
 
 1. Open `start.html` in your `app/views` folder.
-2. Find the `<a>` tag with 'Start now' inside.
-3. Change the value of the `href` attribute from `#` to `/juggling-balls`.
+2. Find the {% raw %}`{{ govukButton({`{% endraw %} component with 'Start now' inside.
+3. Change the `href` from `#` to `/juggling-balls`.
 
 [Go to http://localhost:3000/start](http://localhost:3000/start) and select the **Start now** button to check the link works.
 

--- a/docs/v13/documentation/make-first-prototype/show-users-answers.md.njk
+++ b/docs/v13/documentation/make-first-prototype/show-users-answers.md.njk
@@ -94,7 +94,7 @@ visuallyHiddenText: "your most impressive juggling trick"
 
 The ‘Check answers’ template page has 3 example rows, each row represents a question. We only have 2 questions in our prototype, so we'll delete the last row.
 
-Delete the last row including the comma above it. The row starts on line 56 and ends on line 73.
+Delete the last row including the comma above it: 
 
 ```
 ,


### PR DESCRIPTION
A number of fixes across the tutorial, including:
- removing reference to line numbers on show user's answers 
- typo and link fix on create pages
- switching from html to nunjucks on link pages together