### PR TITLE
Create an .env file

### DIFF
--- a/docs/v13/documentation/using-notify.md.njk
+++ b/docs/v13/documentation/using-notify.md.njk
@@ -31,9 +31,12 @@ To get a key:
 This will let your prototype talk to Notify while it’s running on your
 computer.
 
-To save the key on your computer, add this line to the end of the `.env`
+1. Create a file called `.env` in your prototype folder. 
+
+2. To save the key on your computer, add this line to the end of the `.env`
 file in your prototype (where `xxxxxxx` is the key you’ve copied from
 Notify):
+
 ```shell
 NOTIFYAPIKEY=xxxxxxx
 ```   


### PR DESCRIPTION
Changes to the notify guide to let the user know that they need to create the .env file