### PR TITLE
Simplify tests for docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        node-version: [18.x]
+        os: [ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
There's a lot we can do to improve tests, but this is a quick fix.

Docs only needs to run online, so we don't need tests for Windows, Mac, or older Node versions