### PR TITLE
Fix slack links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We do have a few guidelines to bear in mind.
 If you’ve got an idea or suggestion you can:
 
 * email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk)
-* [get in touch on developer Slack channel](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev)([open in app](slack://channel?team=T04V6EBTR&amp;id=C0E1063DW))
+* [get in touch on developer Slack channel](https://ukgovernmentdigital.slack.com/archives/C0E1063DW)
 * [create a GitHub issue](https://github.com/alphagov/govuk-prototype-kit/issues)
 
 ## Raising bugs

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ You must protect user privacy at all times, even when using prototypes. Prototyp
 The GOV.UK Prototype Kit is maintained by the Government Digital Service. If you’ve got a question or need support you can:
 
 * email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk)
-* [get in touch on Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit)
+* [get in touch on Slack](https://ukgovernmentdigital.slack.com/archives/C0647LW4R)
 * [view known issues on GitHub](https://github.com/alphagov/govuk-prototype-kit/issues)
 
 ## Contributing
 
 If you’ve got an idea or suggestion, you can:
 
-* [get in touch on the developer Slack channel](https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit-dev)
+* [get in touch on the developer Slack channel](https://ukgovernmentdigital.slack.com/archives/C0E1063DW)
 * [create a GitHub issue](https://github.com/alphagov/govuk-prototype-kit/issues)
 
 The govuk-prototype-kit repository is public and we welcome contributions from anyone.

--- a/docs/v12/documentation/install/run-the-kit.md
+++ b/docs/v12/documentation/install/run-the-kit.md
@@ -53,7 +53,7 @@ To quit the kit, in the terminal press the `ctrl` and `c` keys together.
 
 The kit is now installed. Congratulations!
 
-The Prototype Kit is updated regularly. We announce new versions of the Prototype Kit in the [#prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit/). You should [update to the latest version of the kit](../updating-the-kit) to get the latest components, new features and fixes.
+The Prototype Kit is updated regularly. We announce new versions of the Prototype Kit in the [#prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/archives/C0647LW4R). You should [update to the latest version of the kit](../updating-the-kit) to get the latest components, new features and fixes.
 
 ## Make your first prototype
 

--- a/docs/v12/documentation/make-first-prototype/make-first-prototype.md
+++ b/docs/v12/documentation/make-first-prototype/make-first-prototype.md
@@ -21,6 +21,6 @@ Before you start, you must [install and run the GOV.UK Prototype Kit](/docs/inst
 ## Give feedback
 If you would like to give feedback about this tutorial, or you’ve got a question, get in touch with the GOV.UK Design System team:
 
-- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>.
+- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C0647LW4R" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>.
 
 - by email at <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>

--- a/docs/v12/documentation/make-first-prototype/start.md
+++ b/docs/v12/documentation/make-first-prototype/start.md
@@ -37,6 +37,6 @@ You'll also need a code editor. These two are popular, well established and fair
 
 If you would like to give feedback about this tutorial, or you’ve got a question, get in touch with the GOV.UK Design System team:
 
-- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>
+- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C0647LW4R" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>
 
 - by email at <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>

--- a/docs/v12/documentation/updating-the-kit.md
+++ b/docs/v12/documentation/updating-the-kit.md
@@ -12,7 +12,7 @@ To get security patches and new features, make sure you update to the latest ver
 If you have a question or need help with updating the Prototype Kit, you can:
 
 - email govuk-design-system-support@digital.cabinet-office.gov.uk
-- get in touch on the [Prototype Kit's channel on cross-government Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
+- get in touch on the [Prototype Kit's channel on cross-government Slack](https://ukgovernmentdigital.slack.com/archives/C0647LW4R)
 
 Tell us as much as you can about the issue you're having, and the computer and operating system you're using.
 

--- a/docs/v13/documentation/make-first-prototype/start.md.njk
+++ b/docs/v13/documentation/make-first-prototype/start.md.njk
@@ -39,6 +39,6 @@ Before you start with the kit, find out what you need to [install and do](/docs/
 
 If you would like to give feedback about this tutorial, or you’ve got a question, get in touch with the GOV.UK Design System team:
 
-- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>
+- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/archives/C0647LW4R" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>
 
 - by email at <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>

--- a/docs/v13/views/support.html
+++ b/docs/v13/views/support.html
@@ -33,7 +33,7 @@ Support – GOV.UK Prototype Kit
    <h2 class="govuk-heading-l">Slack</h2>
 
     <p>Use the
-<a href="https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit">#prototype-kit channel on cross-government Slack</a>. </p>
+<a href="https://ukgovernmentdigital.slack.com/archives/C0647LW4R">#govuk-prototype-kit channel on cross-government Slack</a>. </p>
 
    <h2 class="govuk-heading-l">Email</h2>
 


### PR DESCRIPTION
We changed the slack channel name which broke some links. This changes all the links to use the id not the name so this won't happen again