### PR TITLE
remove old public folder instruction

### DIFF
--- a/docs/v13/documentation/adding-css-javascript-and-images.md
+++ b/docs/v13/documentation/adding-css-javascript-and-images.md
@@ -106,5 +106,3 @@ Link to it like this:
 ```
 <a href="/public/downloads/report.odf">Download the report</a>
 ```
-
-Do not put files directly in `/public` because it’s deleted and rebuilt every time you make a change to your prototype.


### PR DESCRIPTION
we removed these instructions for v13 as there no longer is a public folder, we missed one