### PR TITLE
Always specify latest when creating and migrating prototypes

### DIFF
--- a/docs/v13/documentation/install/create-a-prototype.md.njk
+++ b/docs/v13/documentation/install/create-a-prototype.md.njk
@@ -61,7 +61,7 @@ If any of your folder names contain spaces, you must add quotation marks around 
 
 Run:
 
-`npx govuk-prototype-kit create`
+`npx govuk-prototype-kit@latest create`
 
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {{ govukPagination({

--- a/docs/v13/documentation/install/getting-started-advanced.md.njk
+++ b/docs/v13/documentation/install/getting-started-advanced.md.njk
@@ -17,7 +17,7 @@ Node.js LTS version 18.x.x
 
 2.  In that folder run:
 
-`npx govuk-prototype-kit create`
+`npx govuk-prototype-kit@latest create`
 
 ## Run the kit
 

--- a/docs/v13/documentation/migrate-an-existing-prototype.md
+++ b/docs/v13/documentation/migrate-an-existing-prototype.md
@@ -15,7 +15,7 @@ title: Migrate an existing prototype to version 13
 
 5. In your prototype folder, run this command in the terminal:
 
-    `npx govuk-prototype-kit@13 migrate`
+    `npx govuk-prototype-kit@latest migrate`
 
 6. If some migration steps fail, the script will report these.
 


### PR DESCRIPTION
This will prevent users from failing to create any new prototypes correctly because without specifying "@latest" the first phase of creating and migrating a prototype uses the version of the govuk-prototype-kit module they originally used the first time they created a prototype locally.