### PR TITLE
Fix incorrect step reference in migration guide

### DIFF
--- a/docs/v13/documentation/migrate-an-existing-prototype.md
+++ b/docs/v13/documentation/migrate-an-existing-prototype.md
@@ -27,7 +27,7 @@ title: Migrate an existing prototype to version 13
 
 ## If your prototype does not work
 
-If your prototype does not work, compare the new `package.json` file to the `package.json` file in the backup you made in step 3.
+If your prototype does not work, compare the new `package.json` file to the `package.json` file in the backup you made in step 4.
 
 Run `npm install PACKAGE-NAME` for each package that's missing in the new file.
 


### PR DESCRIPTION
Step 3 instructs the user to delete their `node_modules` folder – it's step 4 where they are instructed to make a backup:

https://github.com/alphagov/govuk-prototype-kit-docs/blob/259a5dff7c47af21c386cf8c11c94062922958bc/docs/v13/documentation/migrate-an-existing-prototype.md?plain=1#L10-L14