### PR TITLE
Update docs to GOV.UK Frontend to 4.8, enable Tudor crown

### DIFF
--- a/docs/v13/views/layout.html
+++ b/docs/v13/views/layout.html
@@ -38,6 +38,7 @@
 
 {% block header %}
   {{ govukHeader({
+    useTudorCrown: true,
     homepageUrl: baseUrl,
     serviceName: "Prototype Kit version 13",
     serviceUrl: baseUrl,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "fs-extra": "^10.0.1",
-        "govuk-frontend": "^4.4.1",
+        "govuk-frontend": "^4.8.0",
         "gray-matter": "^4.0.3",
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
@@ -4871,9 +4871,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -14290,9 +14290,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
     },
     "govuk-prototype-kit": {
       "version": "0.0.1-alpha.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "fs-extra": "^10.0.1",
-    "govuk-frontend": "^4.4.1",
+    "govuk-frontend": "^4.8.0",
     "gray-matter": "^4.0.3",
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Changes

- Updates the documentation site from Frontend 4.4.1 to 4.8.0.
- Enables the Tudor crown logo for v13 documentation pages.
- Switches favicons to Tudor crown versions.

## Thoughts

- I've left v12 sections using the old crown as this is legacy documentation and is, to some degree, intended to be 'frozen in time'. I'm not sure if we need to update these, but have requested clarification just in case. 