### PR TITLE
Use the Service Navigation

### DIFF
--- a/docs/v12/views/layout.html
+++ b/docs/v12/views/layout.html
@@ -40,12 +40,13 @@
 
 {% block header %}
   {{ govukHeader({
-    homepageUrl: baseUrl,
-    serviceName: serviceName,
-    serviceUrl: baseUrl
+    homepageUrl: "/docs",
+    productName: "Prototype Kit"
   }) }}
   {{
     govukServiceNavigation({
+      serviceName: "v12 and earlier documentation",
+      serviceUrl: baseUrl,
       navigation: [
         {
           href: baseUrl + "/install",

--- a/docs/v12/views/layout.html
+++ b/docs/v12/views/layout.html
@@ -20,6 +20,7 @@
 {% from "govuk/components/phase-banner/macro.njk"  import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk"        import govukRadios %}
 {% from "govuk/components/select/macro.njk"        import govukSelect %}
+{% from "govuk/components/service-navigation/macro.njk"        import govukServiceNavigation %}
 {% from "govuk/components/skip-link/macro.njk"     import govukSkipLink %}
 {% from "govuk/components/table/macro.njk"         import govukTable %}
 {% from "govuk/components/tabs/macro.njk"          import govukTabs %}
@@ -41,31 +42,35 @@
   {{ govukHeader({
     homepageUrl: baseUrl,
     serviceName: serviceName,
-    serviceUrl: baseUrl,
-    navigation: [
-      {
-        href: baseUrl + "/install",
-        text: "Install",
-        attributes: {
-          "data-install": "Install"
-        }
-      },
-      {
-        href: baseUrl + "/tutorials-and-examples",
-        text: "Tutorials and templates",
-        attributes: {
-          "data-tutorials": "Tutorials and templates"
-        }
-      },
-      {
-        href: baseUrl + "/about",
-        text: "About",
-        attributes: {
-          "data-about": "About"
-        }
-      }
-    ]
+    serviceUrl: baseUrl
   }) }}
+  {{
+    govukServiceNavigation({
+      navigation: [
+        {
+          href: baseUrl + "/install",
+          text: "Install",
+          attributes: {
+            "data-install": "Install"
+          }
+        },
+        {
+          href: baseUrl + "/tutorials-and-examples",
+          text: "Tutorials and templates",
+          attributes: {
+            "data-tutorials": "Tutorials and templates"
+          }
+        },
+        {
+          href: baseUrl + "/about",
+          text: "About",
+          attributes: {
+            "data-about": "About"
+          }
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}

--- a/docs/v13/views/layout.html
+++ b/docs/v13/views/layout.html
@@ -39,13 +39,13 @@
 
 {% block header %}
   {{ govukHeader({
-    useTudorCrown: true,
     homepageUrl: baseUrl,
-    serviceName: "Prototype Kit version 13",
-    serviceUrl: baseUrl
+    productName: "Prototype Kit"
   }) }}
   {{
     govukServiceNavigation({
+      serviceName: "v13 documentation",
+      serviceUrl: baseUrl,
       navigation: [
         {
           href: baseUrl + "/create-new-prototype",

--- a/docs/v13/views/layout.html
+++ b/docs/v13/views/layout.html
@@ -20,6 +20,7 @@
 {% from "govuk/components/phase-banner/macro.njk"  import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk"        import govukRadios %}
 {% from "govuk/components/select/macro.njk"        import govukSelect %}
+{% from "govuk/components/service-navigation/macro.njk"        import govukServiceNavigation %}
 {% from "govuk/components/skip-link/macro.njk"     import govukSkipLink %}
 {% from "govuk/components/table/macro.njk"         import govukTable %}
 {% from "govuk/components/tabs/macro.njk"          import govukTabs %}
@@ -41,31 +42,35 @@
     useTudorCrown: true,
     homepageUrl: baseUrl,
     serviceName: "Prototype Kit version 13",
-    serviceUrl: baseUrl,
-    navigation: [
-      {
-        href: baseUrl + "/create-new-prototype",
-        text: "Get started",
-        attributes: {
-          "data-get-started": "Get started"
-        }
-      },
-      {
-        href: baseUrl + "/tutorials-and-guides",
-        text: "Tutorials and guides",
-        attributes: {
-          "data-tutorials": "Tutorials and guides"
-        }
-      },
-      {
-        href: baseUrl + "/support",
-        text: "Support",
-        attributes: {
-          "data-about": "Support"
-        }
-      }
-    ]
+    serviceUrl: baseUrl
   }) }}
+  {{
+    govukServiceNavigation({
+      navigation: [
+        {
+          href: baseUrl + "/create-new-prototype",
+          text: "Get started",
+          attributes: {
+            "data-get-started": "Get started"
+          }
+        },
+        {
+          href: baseUrl + "/tutorials-and-guides",
+          text: "Tutorials and guides",
+          attributes: {
+            "data-tutorials": "Tutorials and guides"
+          }
+        },
+        {
+          href: baseUrl + "/support",
+          text: "Support",
+          attributes: {
+            "data-about": "Support"
+          }
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}


### PR DESCRIPTION
Use the Service Navigation instead of the navigation in the Header, as the latter has been deprecated in [GOV.UK Frontend v5.9.0](https://github.com/alphagov/govuk-frontend/releases/v5.9.0).

Because of deprecations of the `serviceName` in the Header as well, this PR also:
- sets "Prototype Kit" as the product name, so it remains in the header
- uses the `serviceName` option of the Service Navigation to distinguish between the two sections of the site. (v13, and older versions).

[Deploy preview](https://prototype-kit-docs-pr-286.herokuapp.com/)