### PR TITLE
Add docs on applying the govuk brand refresh

### DIFF
--- a/docs/v13/documentation/use-govuk-brand-refresh.md
+++ b/docs/v13/documentation/use-govuk-brand-refresh.md
@@ -1,0 +1,39 @@
+---
+heading: Use the GOV.UK brand refresh in your prototype
+title: Use the GOV.UK brand refresh in your prototype
+---
+
+On 25 June 2025, GDS launched a refreshed GOV.UK brand for web. If you're prototyping a GOV.UK service and your prototype is not using the refreshed GOV.UK brand, we recommend you use the refreshed brand so that it's consistent with the GOV.UK website and other GOV.UK services.
+
+To check if your prototype is using the refreshed GOV.UK brand, see [the guidance on changes to GOV.UK](https://www.gov.uk/guidance/changes-to-govuk). If your prototype is already using the refreshed brand, you do not need to make any changes.
+
+You can update the branding in your prototype using the `rebrand` option in the GOV.UK Frontend Prototype Kit plugin.
+
+Before you start, make sure your prototype is using GOV.UK Frontend v5.10.0 or later.  See [installing and using plugins](/docs/install-and-use-plugins) for details on how to check.
+
+## Add the `rebrand` option and set it to `true`
+
+Go to your prototype's `config.json`, located in your prototype's `app` folder. Add a comma after the `serviceName` line if there isn't one there already. After `serviceName` but still within the curly brackets, enter the following:
+
+```json
+"plugins": {
+  "govuk-frontend": {
+    "rebrand": true
+  }
+}
+```
+
+If there was nothing else besides `serviceName` in your config, it should now look like this:
+
+```json
+{
+  "serviceName": "Your service name",
+  "plugins": {
+    "govuk-frontend": {
+      "rebrand": true
+    }
+  }
+}
+```
+
+If you haven't already, start your prototype locally, [using the instructions on running the kit](/docs/install/how-to-run-the-kit). You should now see the refreshed GOV.UK brand.

--- a/docs/v13/views/tutorials-and-guides.html
+++ b/docs/v13/views/tutorials-and-guides.html
@@ -171,6 +171,9 @@
         <li>
           <a href="./migrate-an-existing-prototype">Migrate an existing prototype to version 13</a>
         </li>
+        <li>
+          <a href="./use-govuk-brand-refresh">Use the GOV.UK brand refresh in your prototype</a>
+        </li>
       </ul>
       <h3 class="govuk-heading-s">Creating plugins</h3>
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Adds how to apply the brand updates from 5.10.0 onward to the kit.

A step towards https://github.com/alphagov/govuk-prototype-kit-docs/issues/290, but doesn't resolve it completely until https://github.com/alphagov/govuk-prototype-kit/pull/2451 is merged.

There's an operational point here around telling users creating new prototypes that the brand refresh is applied automatically once https://github.com/alphagov/govuk-prototype-kit/pull/2451 is done. We could either release this now and come back to it later to add a point on new prototypes, or wait until a new version of the kit is out and amend this to contain that content. My instinct is that there's value in releasing this as is now and amending it later so that users get the info they need sooner.