### PR TITLE
Remove `$legacy` param

### DIFF
--- a/docs/v12/assets/sass/docs.scss
+++ b/docs/v12/assets/sass/docs.scss
@@ -53,7 +53,7 @@ figure {
   overflow: auto;
   border: $govuk-focus-width solid transparent;
   outline: 1px solid $govuk-border-colour;
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
   max-width: 38em;
   @include govuk-responsive-margin(5, "bottom");
 
@@ -120,7 +120,7 @@ figure {
   p code,
   li code {
     color: #d13118;
-    background-color: govuk-colour("light-grey", $legacy: "grey-4");
+    background-color: govuk-colour("light-grey");
     padding: 0 govuk-spacing(1);
   }
 

--- a/docs/v12/assets/sass/patterns/_pagination.scss
+++ b/docs/v12/assets/sass/patterns/_pagination.scss
@@ -33,7 +33,7 @@
 
   &:hover,
   &:active {
-    background-color: govuk-colour("light-grey", $legacy: "grey-4");
+    background-color: govuk-colour("light-grey");
 
     // Add govuk-link hover decoration to title if no label present
     .app-pagination__link-text--decorated {
@@ -80,7 +80,7 @@
   margin-bottom: 1px;
   height: .482em;
   width: .63em;
-  fill: govuk-colour("dark-grey", $legacy: "grey-1");
+  fill: govuk-colour("dark-grey");
 }
 
 .app-pagination__link-label {

--- a/docs/v13/assets/sass/docs.scss
+++ b/docs/v13/assets/sass/docs.scss
@@ -53,7 +53,7 @@ figure {
   overflow: auto;
   border: $govuk-focus-width solid transparent;
   outline: 1px solid $govuk-border-colour;
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
   max-width: 38em;
   @include govuk-responsive-margin(5, "bottom");
 
@@ -120,7 +120,7 @@ figure {
   p code,
   li code {
     color: #d13118;
-    background-color: govuk-colour("light-grey", $legacy: "grey-4");
+    background-color: govuk-colour("light-grey");
     padding: 0 govuk-spacing(1);
   }
 

--- a/docs/v13/assets/sass/patterns/_pagination.scss
+++ b/docs/v13/assets/sass/patterns/_pagination.scss
@@ -33,7 +33,7 @@
 
   &:hover,
   &:active {
-    background-color: govuk-colour("light-grey", $legacy: "grey-4");
+    background-color: govuk-colour("light-grey");
 
     // Add govuk-link hover decoration to title if no label present
     .app-pagination__link-text--decorated {
@@ -80,7 +80,7 @@
   margin-bottom: 1px;
   height: .482em;
   width: .63em;
-  fill: govuk-colour("dark-grey", $legacy: "grey-1");
+  fill: govuk-colour("dark-grey");
 }
 
 .app-pagination__link-label {


### PR DESCRIPTION
What it says. The `$legacy` param is deprecated and will be removed in frontend v6, so lets scoop it out.

Adjacent to https://github.com/alphagov/govuk-prototype-kit/issues/2469