### PR TITLE
Update kit docs to use node 24

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5.0.0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4.4.0
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'

--- a/.github/workflows/test-heroku.yaml
+++ b/.github/workflows/test-heroku.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node v18
-      uses: actions/setup-node@v3
+    - uses: actions/checkout@v5.0.0
+    - name: Use Node v24
+      uses: actions/setup-node@v6.0.0
       with:
         cache: 'npm'
-        node-version: '18'
+        node-version-file: '.nvmrc'
     - run: npm ci
     - run: npm run test:heroku

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
         os: [ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
@@ -27,23 +27,23 @@ jobs:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
 
       - name: Use Node v${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.4.0
         with:
           cache: 'npm'
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Cypress binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4.3.0
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
 
-      - run: npm install -g npm@8
+      - run: npm install
 
       - run: npm ci
         env:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+24

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,8 @@
         "wait-on": "^6.0.1"
       },
       "engines": {
-        "node": "18.x"
+        "node": "24.11.0",
+        "npm": "11.6.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -92,6 +93,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
       "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -2051,6 +2053,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
       "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3691,6 +3694,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -3929,6 +3933,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
@@ -4097,6 +4102,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
       "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "eslint-plugin-es": "^2.0.0",
         "eslint-utils": "^1.4.2",
@@ -4126,6 +4132,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4135,6 +4142,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
       "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
@@ -4184,6 +4192,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -12948,6 +12957,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
       "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -14477,7 +14487,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
       "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -15700,6 +15711,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -16152,6 +16164,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
@@ -16280,6 +16293,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
       "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "eslint-plugin-es": "^2.0.0",
         "eslint-utils": "^1.4.2",
@@ -16301,13 +16315,15 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "eslint-plugin-react": {
       "version": "7.14.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
       "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
@@ -16336,6 +16352,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.2.tgz",
       "integrity": "sha512-nKptN8l7jksXkwFk++PhJB3cCDTcXOEyhISIN86Ue2feJ1LFyY3PrY3/xT2keXlJSY5bpmbiTG0f885/YKAvTA==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": "18.x"
+    "node": "24.11.0",
+    "npm": "11.6.0"
   },
   "scripts": {
     "build": "node lib/build/generate-assets",


### PR DESCRIPTION
Updates the docs to run on Node 24 rather than 18 as 24 is node's current LTS.

Specific changes:

- Update the `.nvmrc` to 24
- Update the `package` engine and reinstall
- Reference node 24 and `.nvmrc` in automated tests where possible
- Update github action plugins to the latest versions whilst we're here