### PR TITLE
Replace design system contact url

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Get in touch another way
-    url: https://design-system.service.gov.uk/get-in-touch/
+    url: https://design-system.service.gov.uk/contact/
     about: Find out how to get in touch via email or Slack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contribution guidelines
 
 
-The GOV.UK Prototype Kit is currently maintained by the [GOV.UK Design System team](https://design-system.service.gov.uk/get-in-touch/).
+The GOV.UK Prototype Kit is currently maintained by the [GOV.UK Design System team](https://design-system.service.gov.uk/contact/).
 
 [There is only minimal support in place](https://github.com/alphagov/govuk-prototype-kit/issues/2389) so we cannot work on contributions at this time.
 

--- a/docs/v12/views/about.html
+++ b/docs/v12/views/about.html
@@ -28,7 +28,7 @@ About – GOV.UK Prototype Kit
       <h2 class="govuk-heading-m">Support</h2>
 
       <p>The GOV.UK Prototype Kit is currently maintained by the
-        <a href="https://design-system.service.gov.uk/get-in-touch/">GOV.UK Design System team</a>, who can only provide
+        <a href="https://design-system.service.gov.uk/contact/">GOV.UK Design System team</a>, who can only provide
         <a href="https://github.com/alphagov/govuk-prototype-kit/issues/2389">limited support</a>.</p>
 
       <p>If you’ve got a question, idea or suggestion, share with the community of users on the

--- a/docs/v13/views/support.html
+++ b/docs/v13/views/support.html
@@ -23,7 +23,7 @@
       <h1 class="govuk-heading-xl">Support</h1>
 
       <p>The GOV.UK Prototype Kit is currently maintained by the
-        <a href="https://design-system.service.gov.uk/get-in-touch/">GOV.UK Design System team</a>, who can only provide
+        <a href="https://design-system.service.gov.uk/contact/">GOV.UK Design System team</a>, who can only provide
         <a href="https://github.com/alphagov/govuk-prototype-kit/issues/2389">limited support</a>.</p>
 
       <p>If you’ve got a question, idea or suggestion, share with the community of users on the


### PR DESCRIPTION
Replaces links to `https://design-system.service.gov.uk/get-in-touch/` with `https://design-system.service.gov.uk/contact/`

Doing in response to https://github.com/alphagov/govuk-design-system/pull/5068. This isn't the biggest deal since we redirect but is the neater option.