### PR TITLE
Update guidance on customising layouts

### DIFF
--- a/docs/v13/documentation/how-to-use-layouts.md
+++ b/docs/v13/documentation/how-to-use-layouts.md
@@ -31,72 +31,15 @@ You can make changes to existing blocks and define your own blocks in your layou
 
 If you do not want to use the GOV.UK logo or footer, you can choose to use unbranded pages in your prototype. Go to <strong>Manage your prototype</strong> and create a page with the <strong>Unbranded page</strong> template.
 
-## Using blocks
+## Changing template content
 
-Blocks are how layouts and pages share code. For example, there is a block called `header` for the header content on every page.
+You can change parts of the template by setting variables and blocks, for example:
 
-These are some of the default blocks on the [template page on the GOV.UK Design System](https://design-system.service.gov.uk/styles/page-template/#exploded-view-of-the-page-template-block-areas).
+- customising or replacing the default header, service navigation or footer
+- setting the `content` block to add content to the page
+- adding your own content to other blocks
 
-### Header block
-
-You can make changes to the existing GOV.UK header using the `header` block. This example adds navigation:
-
-```
-{% block header %}
-{{ govukHeader({
-  homepageUrl: "#",
-  serviceName: "Service name",
-  serviceUrl: "#",
-  navigation: [
-    {
-      href: "#1",
-      text: "Navigation item 1",
-      active: true
-    },
-    {
-      href: "#2",
-      text: "Navigation item 2"
-    },
-    {
-      href: "#3",
-      text: "Navigation item 3"
-    }
-  ]
-}) }}
-{% endblock %}
- ```
-
-Read more about [headers in the GOV.UK Design System](https://design-system.service.gov.uk/components/header/).
-
-### Footer block
-
-You can make changes to the existing GOV.UK footer using the `footer` block:
-
-```
-{% block footer %}
- {{ govukFooter({
-   meta: {
-     items: [
-       {
-         href: "/privacy",
-         text: "Privacy policy"
-       },
-       {
-         href: "/manage-prototype",
-         text: "Manage your prototype"
-       },
-       {
-         href: "/manage-prototype/clear-data",
-         text: "Clear data"
-       }
-     ],
-     visuallyHiddenTitle: "Footer links"
-   }
- }) }}
-{% endblock %}
-```
-
-Read more about [footers in the GOV.UK Design System](https://design-system.service.gov.uk/components/footer/).
+[See the page template guidance on the GOV.UK Design System](https://design-system.service.gov.uk/styles/page-template/) for more information on how to change template content.
 
 ## Stylesheets (CSS) and JavaScript
 


### PR DESCRIPTION
We’ve made significant changes to the blocks in the page template in GOV.UK Frontend v6 which means this guidance is out of date.

For example, rather than setting the `header` block in most cases we want the user to set the `govukHeader` block.

To try and avoid having multiple pieces of overlapping guidance to keep up to date, rather than updating the blocks, I’ve stripped the content back to the absolute minimum. Instead we can push users towards the page template guidance in the Design System.

I have however specifically called out the `content` block, because users will almost always need to set it to actually add content to the page (unless they’re setting e.g. `main` instead) and it’s otherwise pretty buried in the page template guidance.