### PR TITLE
Update guidance on customising layouts

### DIFF
--- a/docs/v13/documentation/how-to-use-layouts.md
+++ b/docs/v13/documentation/how-to-use-layouts.md
@@ -33,11 +33,11 @@ If you do not want to use the GOV.UK logo or footer, you can choose to use unbra
 
 ## Using blocks
 
-Blocks are how layouts and pages share code. For example, there is a block called `govukHeader` for the header on every page.
+Blocks are how layouts and pages share code. For example, there's a block called `govukHeader` for the header on every page.
 
 You can use blocks to:
 
-- customise or replace the default header, service navigation or footer
+- customise or replace the default GOV.UK header, GOV.UK footer or Service navigation components
 - add your own content to parts of the page
 - include extra scripts or stylesheets in the page
 
@@ -45,9 +45,9 @@ You can use blocks to:
 
 ### Customising service navigation
 
-Your prototype will already include [service navigation](https://design-system.service.gov.uk/components/service-navigation/) if you've set `serviceName` in the config for your prototype.
+Your prototype will already include the [Service navigation component](https://design-system.service.gov.uk/components/service-navigation/) if you've set `serviceName` in the config for your prototype.
 
-If you want to add additional links to your service navigation, you'll need to use the `govukServiceNavigation` block to replace the default service navigation with your own:
+If you want to add additional links to your Service navigation, you'll need to use the `govukServiceNavigation` block to replace the default Service navigation component with your own:
 
 ```
 {% block govukServiceNavigation %}

--- a/docs/v13/documentation/how-to-use-layouts.md
+++ b/docs/v13/documentation/how-to-use-layouts.md
@@ -33,47 +33,51 @@ If you do not want to use the GOV.UK logo or footer, you can choose to use unbra
 
 ## Using blocks
 
-Blocks are how layouts and pages share code. For example, there is a block called `header` for the header content on every page.
+Blocks are how layouts and pages share code. For example, there is a block called `govukHeader` for the header on every page.
 
-These are some of the default blocks on the [template page on the GOV.UK Design System](https://design-system.service.gov.uk/styles/page-template/#exploded-view-of-the-page-template-block-areas).
+You can use blocks to:
 
-### Header block
+- customise or replace the default header, service navigation or footer
+- add your own content to parts of the page
+- include extra scripts or stylesheets in the page
 
-You can make changes to the existing GOV.UK header using the `header` block. This example adds navigation:
+[See the page template guidance on the GOV.UK Design System](https://design-system.service.gov.uk/styles/page-template/) for a list of all the blocks you can use.
+
+### Customising service navigation
+
+Your prototype will already include [service navigation](https://design-system.service.gov.uk/components/service-navigation/) if you've set `serviceName` in the config for your prototype.
+
+If you want to add additional links to your service navigation, you'll need to use the `govukServiceNavigation` block to replace the default service navigation with your own:
 
 ```
-{% block header %}
-{{ govukHeader({
-  homepageUrl: "#",
-  serviceName: "Service name",
-  serviceUrl: "#",
-  navigation: [
-    {
-      href: "#1",
-      text: "Navigation item 1",
-      active: true
-    },
-    {
-      href: "#2",
-      text: "Navigation item 2"
-    },
-    {
-      href: "#3",
-      text: "Navigation item 3"
-    }
-  ]
-}) }}
+{% block govukServiceNavigation %}
+  {{ govukServiceNavigation({
+    serviceName: serviceName,
+    navigation: [
+      {
+        href: "#",
+        text: "Navigation item 1"
+      },
+      {
+        href: "#",
+        text: "Navigation item 2",
+        active: true
+      },
+      {
+        href: "#",
+        text: "Navigation item 3"
+      }
+    ]
+  }) }}
 {% endblock %}
  ```
 
-Read more about [headers in the GOV.UK Design System](https://design-system.service.gov.uk/components/header/).
-
 ### Footer block
 
-You can make changes to the existing GOV.UK footer using the `footer` block:
+You can make changes to the [GOV.UK footer](https://design-system.service.gov.uk/components/footer/) using the `govukFooter` block:
 
 ```
-{% block footer %}
+{% block govukFooter %}
  {{ govukFooter({
    meta: {
      items: [
@@ -95,8 +99,6 @@ You can make changes to the existing GOV.UK footer using the `footer` block:
  }) }}
 {% endblock %}
 ```
-
-Read more about [footers in the GOV.UK Design System](https://design-system.service.gov.uk/components/footer/).
 
 ## Stylesheets (CSS) and JavaScript
 


### PR DESCRIPTION
This is a second attempt at trying to update the guidance on customising layouts, iterated based on feedback received in #301.

We’ve made significant changes to the blocks in the page template in GOV.UK Frontend v6 which means this guidance is out of date.

Setting the `header` block now overrides the entire semantic `<header>` element, including the header but also e.g. service navigation.

With most of the service-level moved out of the header into the service nav component, there are few reasons for users to need to modify the govukHeader block unless they need to set a productName, for example.

(Service navigation is now automatically included in the page template if `serviceName` is set, which it should be in most prototypes.)

Replace the header block example with guidance on adding navigation links to the service nav.

This should be sufficient for users who just want to add navigation to their prototype (as described by the previous example), but users who are looking to e.g. replace the header entirely will need to use other blocks that are only covered in the linked page template guidance.

Update the footer example to use the `govukFooter` block, and to inline the link to the footer guidance in the Design System.

Rework the introductory paragraphs to help users better understand that these are just two examples of the things they can do with blocks, and point them to the fuller page template guidance in the Design System which shows all the blocks and variables available to customise the page template.