### PR TITLE
Replace references to node 22 with node 24

### DIFF
--- a/docs/v13/documentation/install/getting-started-advanced.md.njk
+++ b/docs/v13/documentation/install/getting-started-advanced.md.njk
@@ -9,7 +9,7 @@ The Prototype Kit runs in Node.js. It is built on the [Express framework](http:/
 
 ## Requirements
 
-Node.js LTS version 22.x.x
+Node.js LTS version 24.x.x
 
 ## Create a prototype
 

--- a/docs/v13/documentation/install/node-linux.md.njk
+++ b/docs/v13/documentation/install/node-linux.md.njk
@@ -4,7 +4,7 @@ heading: Install Node.js (Linux)
 caption: Create a prototype for new users
 ---
 
-The kit is designed to work with Node.js version 22 and above.
+The kit is designed to work with Node.js version 24 and above.
 
 ### Check if you have Node.js
 
@@ -14,13 +14,13 @@ node --version
 ```
 If it says `command not found` you do not have Node and will need to download and install it.
 
-If the version number starts with 22 you have the correct version installed.
+If the version number starts with 24 you have the correct version installed.
 
-If it starts with a number lower than 22, you need to download and install version 22.
+If it starts with a number lower than 24, you need to download and install version 24.
 
 ### Download and install Node.js
 
-[Follow the Linux instructions on the Node.js. website](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions). Make sure you get version 22.
+[Follow the Linux instructions on the Node.js. website](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions). Make sure you get version 24.
 
 ### Once Node is installed
 
@@ -31,7 +31,7 @@ To check it's installed correctly you can again run:
 node --version
 ```
 
-If it’s installed correctly it should show a number starting with 22.
+If it’s installed correctly it should show a number starting with 24.
 
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {{ govukPagination({

--- a/docs/v13/documentation/install/node-mac.md.njk
+++ b/docs/v13/documentation/install/node-mac.md.njk
@@ -4,7 +4,7 @@ heading: Install Node.js (Mac)
 caption: Create a prototype for new users
 ---
 
-The kit is designed to work with Node.js version 22 and above.
+The kit is designed to work with Node.js version 24 and above.
 
 ### Check if you have Node.js
 
@@ -14,13 +14,13 @@ node --version
 ```
 If it says `command not found` you do not have Node and will need to download and install it.
 
-If the version number starts with 22 you have the correct version installed.
+If the version number starts with 24 you have the correct version installed.
 
-If it starts with a number lower than 22, you need to download and install version 22.
+If it starts with a number lower than 24, you need to download and install version 24.
 
 ### Download and install Node.js
 
-[Download version 22 from the Node.js website.](https://nodejs.org/en/)
+[Download version 24 from the Node.js website.](https://nodejs.org/en/)
 
 Run the installer with all default options.
 
@@ -33,7 +33,7 @@ To check it's installed correctly you can again run:
 node --version
 ```
 
-If it’s installed correctly it should show a number starting with 22.
+If it’s installed correctly it should show a number starting with 24.
 
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {{ govukPagination({

--- a/docs/v13/documentation/install/node-windows.md.njk
+++ b/docs/v13/documentation/install/node-windows.md.njk
@@ -4,7 +4,7 @@ heading: Install Node.js (Windows)
 caption: Create a prototype for new users
 ---
 
-The kit is designed to work with Node.js version 22 and above.
+The kit is designed to work with Node.js version 24 and above.
 
 ### Check if you have Node.js
 
@@ -14,13 +14,13 @@ node --version
 ```
 If it says `command not found` or `Error 0x2 starting node.exe --version` you do not have Node and will need to download and install it.
 
-If the version number starts with 22 you have the correct version installed.
+If the version number starts with 24 you have the correct version installed.
 
-If it starts with a number lower than 22, you need to download and install version 22.
+If it starts with a number lower than 24, you need to download and install version 24.
 
 ### Download and install Node.js
 
-[Download version 22 from the Node.js website.](https://nodejs.org/en/)
+[Download version 24 from the Node.js website.](https://nodejs.org/en/)
 
 Run the installer with all default options.
 
@@ -33,7 +33,7 @@ To check it is installed correctly you can again run:
 node --version
 ```
 
-If it’s installed correctly it should show a number starting with 22.
+If it’s installed correctly it should show a number starting with 24.
 
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {{ govukPagination({

--- a/docs/v13/documentation/migrate-an-existing-prototype.md
+++ b/docs/v13/documentation/migrate-an-existing-prototype.md
@@ -3,7 +3,7 @@ heading: Migrate an existing prototype to version 13
 title: Migrate an existing prototype to version 13
 ---
 
-1. If you do not already have it, [install Node.js version 22](https://nodejs.org/en).
+1. If you do not already have it, [install Node.js version 24](https://nodejs.org/en).
 
 2. In the terminal, change to your prototype folder. 
 

--- a/docs/v13/documentation/whats-new.md
+++ b/docs/v13/documentation/whats-new.md
@@ -49,7 +49,7 @@ There is a new approach to routes, templates and layouts:
 
 ### Using Node.js
 
-The Prototype Kit no longer supports versions 12, 14 or 16 of Node.js. We recommend you update to the latest LTS version Node.js 22.
+The Prototype Kit no longer supports versions 12, 14 or 16 of Node.js. We recommend you update to the latest LTS version Node.js 24.
 
 ### GOV.UK Frontend
 When creating a new prototype, you will always have the latest version of GOV.UK Frontend.


### PR DESCRIPTION
Follows https://github.com/alphagov/govuk-prototype-kit/issues/2445#issuecomment-4010781949

The kit is now setup to support node 24 and 24 is the current LTS version so we should encourage users to use it over 22