### PR TITLE
Generate id attributes for markdown headings

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 const matter = require('gray-matter')
 const { marked } = require('marked')
+const { gfmHeadingId } = require('marked-gfm-heading-id')
 
 // Tweak the Markdown renderer
 const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()
@@ -23,6 +24,8 @@ marked.use({
     }
   }
 })
+
+marked.use(gfmHeadingId())
 
 exports.findViewName = function (mdDir, name) {
   for (const ext of ['.md.njk', '.md']) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
         "marked": "^15.0.12",
+        "marked-gfm-heading-id": "^4.1.4",
         "memorystore": "^1.6.7",
         "nodemon": "^2.0.15",
         "nunjucks": "^3.2.1",
@@ -93,7 +94,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
       "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -2053,7 +2053,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
       "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3694,7 +3693,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -3933,7 +3931,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
@@ -4102,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
       "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "eslint-plugin-es": "^2.0.0",
         "eslint-utils": "^1.4.2",
@@ -4132,7 +4128,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4142,7 +4137,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
       "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
@@ -4192,7 +4186,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -5401,6 +5394,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -8310,6 +8309,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/marked-gfm-heading-id": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/marked-gfm-heading-id/-/marked-gfm-heading-id-4.1.4.tgz",
+      "integrity": "sha512-CspnvVfHSkb/znqdPS4jUR8HtCjq3M/DnrsJCrfLBLvdrgbemmoINKpeWKQYkBiXAoBGejw0cV7xzqrPdup3WA==",
+      "license": "MIT",
+      "dependencies": {
+        "github-slugger": "^2.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=13 <19"
       }
     },
     "node_modules/mdast-comment-marker": {
@@ -12957,7 +12968,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
       "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -14487,8 +14497,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
       "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -15711,7 +15720,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -16164,7 +16172,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
@@ -16293,7 +16300,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
       "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "eslint-plugin-es": "^2.0.0",
         "eslint-utils": "^1.4.2",
@@ -16315,15 +16321,13 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.14.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
       "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
@@ -16352,7 +16356,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.2.tgz",
       "integrity": "sha512-nKptN8l7jksXkwFk++PhJB3cCDTcXOEyhISIN86Ue2feJ1LFyY3PrY3/xT2keXlJSY5bpmbiTG0f885/YKAvTA==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "eslint-scope": {
@@ -16985,6 +16988,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "glob": {
       "version": "7.2.0",
@@ -19101,6 +19109,14 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="
+    },
+    "marked-gfm-heading-id": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/marked-gfm-heading-id/-/marked-gfm-heading-id-4.1.4.tgz",
+      "integrity": "sha512-CspnvVfHSkb/znqdPS4jUR8HtCjq3M/DnrsJCrfLBLvdrgbemmoINKpeWKQYkBiXAoBGejw0cV7xzqrPdup3WA==",
+      "requires": {
+        "github-slugger": "^2.0.0"
+      }
     },
     "mdast-comment-marker": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",
     "marked": "^15.0.12",
+    "marked-gfm-heading-id": "^4.1.4",
     "memorystore": "^1.6.7",
     "nodemon": "^2.0.15",
     "nunjucks": "^3.2.1",


### PR DESCRIPTION
Resolves an issue where skip links on https://prototype-kit.service.gov.uk/docs/configure-plugin expects headings to link to.

Generates IDs similar to how GitHub does it (hence the gfm plugin).

Thank you to @joelanman for raising the issue.

Closes #305 